### PR TITLE
유저 회원가입 기능

### DIFF
--- a/src/main/java/com/my/foody/domain/user/controller/UserController.java
+++ b/src/main/java/com/my/foody/domain/user/controller/UserController.java
@@ -1,9 +1,24 @@
 package com.my.foody.domain.user.controller;
 
+import com.my.foody.domain.user.service.UserService;
+import com.my.foody.global.util.api.ApiResult;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
+@RequestMapping("/api/users")
+@RequiredArgsConstructor
 public class UserController {
+
+    private final UserService userService;
+
+    public void register(){
+
+    }
+
+
 
 
 

--- a/src/main/java/com/my/foody/domain/user/controller/UserController.java
+++ b/src/main/java/com/my/foody/domain/user/controller/UserController.java
@@ -1,9 +1,15 @@
 package com.my.foody.domain.user.controller;
 
+import com.my.foody.domain.user.dto.req.UserSignUpReqDto;
+import com.my.foody.domain.user.dto.resp.UserSignUpRespDto;
 import com.my.foody.domain.user.service.UserService;
 import com.my.foody.global.util.api.ApiResult;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -13,9 +19,9 @@ import org.springframework.web.bind.annotation.RestController;
 public class UserController {
 
     private final UserService userService;
-
-    public void register(){
-
+    @PostMapping("/signup")
+    public ResponseEntity<ApiResult<UserSignUpRespDto>> signUp(@RequestBody @Valid UserSignUpReqDto userSignUpReqDto){
+        return new ResponseEntity<>(ApiResult.success(userService.signUp(userSignUpReqDto)), HttpStatus.CREATED);
     }
 
 

--- a/src/main/java/com/my/foody/domain/user/dto/req/UserJoinReqDto.java
+++ b/src/main/java/com/my/foody/domain/user/dto/req/UserJoinReqDto.java
@@ -1,4 +1,0 @@
-package com.my.foody.domain.user.dto.req;
-
-public class UserJoinReqDto {
-}

--- a/src/main/java/com/my/foody/domain/user/dto/req/UserSignUpReqDto.java
+++ b/src/main/java/com/my/foody/domain/user/dto/req/UserSignUpReqDto.java
@@ -1,0 +1,31 @@
+package com.my.foody.domain.user.dto.req;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.validator.constraints.Length;
+
+@NoArgsConstructor
+@Getter
+public class UserSignUpReqDto {
+
+    @Email(message = "유효하지 않은 이메일 형식입니다")
+    @NotBlank(message = "이메일을 입력해야 합니다")
+    private String email;
+
+    @NotBlank(message = "이름을 입력해야 합니다")
+    @Length(min = 1, max = 100, message = "이름은 최소 1자 최대 100자로 입력해야 합니다")
+    private String name;
+
+    @NotBlank(message = "전화번호를 입력해야 합니다")
+    @Length(max = 15, message = "전화번호는 15자 이내여야 합니다")
+    private String contact;
+
+    @NotBlank(message = "비밀번호를 입력해야 합니다")
+    private String password;
+
+    @NotBlank(message = "닉네임을 입력해야 합니다")
+    @Length(min = 1, max = 100, message = "닉네임은 최소 1자 최대 100자로 입력해야 합니다")
+    private String nickname;
+}

--- a/src/main/java/com/my/foody/domain/user/dto/req/UserSignUpReqDto.java
+++ b/src/main/java/com/my/foody/domain/user/dto/req/UserSignUpReqDto.java
@@ -1,5 +1,7 @@
 package com.my.foody.domain.user.dto.req;
 
+import com.my.foody.domain.user.entity.User;
+import com.my.foody.global.util.PasswordEncoder;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import lombok.Getter;
@@ -28,4 +30,15 @@ public class UserSignUpReqDto {
     @NotBlank(message = "닉네임을 입력해야 합니다")
     @Length(min = 1, max = 100, message = "닉네임은 최소 1자 최대 100자로 입력해야 합니다")
     private String nickname;
+
+    public User toEntity(){
+        return User.builder()
+                .contact(contact)
+                .email(email)
+                .nickname(nickname)
+                .password(PasswordEncoder.encode(password))
+                .name(name)
+                .isDeleted(false)
+                .build();
+    }
 }

--- a/src/main/java/com/my/foody/domain/user/dto/req/UserSignUpReqDto.java
+++ b/src/main/java/com/my/foody/domain/user/dto/req/UserSignUpReqDto.java
@@ -4,12 +4,16 @@ import com.my.foody.domain.user.entity.User;
 import com.my.foody.global.util.PasswordEncoder;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.validator.constraints.Length;
 
 @NoArgsConstructor
 @Getter
+@AllArgsConstructor
+@Builder
 public class UserSignUpReqDto {
 
     @Email(message = "유효하지 않은 이메일 형식입니다")

--- a/src/main/java/com/my/foody/domain/user/dto/req/valid/PasswordValidator.java
+++ b/src/main/java/com/my/foody/domain/user/dto/req/valid/PasswordValidator.java
@@ -1,0 +1,49 @@
+package com.my.foody.domain.user.dto.req.valid;
+
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class PasswordValidator implements ConstraintValidator<ValidPassword, String> {
+
+    @Override
+    public boolean isValid(String password, ConstraintValidatorContext context) {
+        if(password == null){
+            return false;
+        }
+        context.disableDefaultConstraintViolation();
+        List<String> errorMsg = validate(password);
+        if(!errorMsg.isEmpty()){
+            errorMsg.forEach(msg ->
+                    context.buildConstraintViolationWithTemplate(msg)
+                    .addConstraintViolation());
+            return false;
+        }
+        return true;
+    }
+
+    private List<String> validate(String password){
+        List<String> errors = new ArrayList<>();
+
+        if (password.length() < 8 || password.length() > 16) {
+            errors.add("비밀번호는 8~16자리여야 합니다");
+        }
+
+        if (!password.matches(".*[A-Za-z].*")) {
+            errors.add("영문자를 최소 1자 이상 포함해야 합니다");
+        }
+
+        if (!password.matches(".*\\d.*")) {
+            errors.add("숫자를 최소 1자 이상 포함해야 합니다");
+        }
+
+        if (!password.matches(".*[@$!%*#?&].*")) {
+            errors.add("특수문자를 최소 1자 이상 포함해야 합니다");
+        }
+
+        return errors;
+    }
+
+}

--- a/src/main/java/com/my/foody/domain/user/dto/req/valid/ValidPassword.java
+++ b/src/main/java/com/my/foody/domain/user/dto/req/valid/ValidPassword.java
@@ -1,0 +1,16 @@
+package com.my.foody.domain.user.dto.req.valid;
+
+import jakarta.validation.Constraint;
+import org.springframework.context.annotation.Configuration;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.FIELD)
+@Retention(RetentionPolicy.RUNTIME)
+@Constraint(validatedBy = PasswordValidator.class)
+public @interface ValidPassword {
+    String message() default "유효하지 않은 비밀번호입니다";
+}

--- a/src/main/java/com/my/foody/domain/user/dto/resp/UserSignUpRespDto.java
+++ b/src/main/java/com/my/foody/domain/user/dto/resp/UserSignUpRespDto.java
@@ -1,4 +1,13 @@
 package com.my.foody.domain.user.dto.resp;
 
+import lombok.Getter;
+
+@Getter
 public class UserSignUpRespDto {
+    private static final String SUCCESS_MESSAGE = "회원가입 되었습니다";
+    private final String message;
+
+    public UserSignUpRespDto() {
+        this.message = SUCCESS_MESSAGE;
+    }
 }

--- a/src/main/java/com/my/foody/domain/user/dto/resp/UserSignUpRespDto.java
+++ b/src/main/java/com/my/foody/domain/user/dto/resp/UserSignUpRespDto.java
@@ -1,4 +1,4 @@
 package com.my.foody.domain.user.dto.resp;
 
-public class UserJoinRespDto {
+public class UserSignUpRespDto {
 }

--- a/src/main/java/com/my/foody/domain/user/entity/User.java
+++ b/src/main/java/com/my/foody/domain/user/entity/User.java
@@ -3,6 +3,7 @@ package com.my.foody.domain.user.entity;
 import com.my.foody.domain.base.BaseEntity;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -27,4 +28,14 @@ public class User extends BaseEntity {
     @Column(nullable = false)
     private Boolean isDeleted;
 
+    @Builder
+    public User(Long id, String name, String nickname, String password, String email, String contact, Boolean isDeleted) {
+        this.id = id;
+        this.name = name;
+        this.nickname = nickname;
+        this.password = password;
+        this.email = email;
+        this.contact = contact;
+        this.isDeleted = isDeleted;
+    }
 }

--- a/src/main/java/com/my/foody/domain/user/repo/UserRepository.java
+++ b/src/main/java/com/my/foody/domain/user/repo/UserRepository.java
@@ -4,6 +4,12 @@ import com.my.foody.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
+
 @Repository
 public interface UserRepository extends JpaRepository<User, Long> {
+
+    boolean existsByEmail(String email);
+
+    boolean existsByNickname(String nickname);
 }

--- a/src/main/java/com/my/foody/domain/user/service/UserService.java
+++ b/src/main/java/com/my/foody/domain/user/service/UserService.java
@@ -1,4 +1,25 @@
 package com.my.foody.domain.user.service;
 
+import com.my.foody.domain.user.dto.req.UserSignUpReqDto;
+import com.my.foody.domain.user.dto.resp.UserSignUpRespDto;
+import com.my.foody.domain.user.repo.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class UserService {
+    private final UserRepository userRepository;
+
+    public UserSignUpRespDto join(UserSignUpReqDto userSignUpReqDto){
+        //이메일 중복 검사
+
+        //닉네임 중복 검사
+
+        //엔티티 전환(비밀번호 인코딩)
+
+    }
+
 }

--- a/src/main/java/com/my/foody/domain/user/service/UserService.java
+++ b/src/main/java/com/my/foody/domain/user/service/UserService.java
@@ -2,24 +2,34 @@ package com.my.foody.domain.user.service;
 
 import com.my.foody.domain.user.dto.req.UserSignUpReqDto;
 import com.my.foody.domain.user.dto.resp.UserSignUpRespDto;
+import com.my.foody.domain.user.entity.User;
 import com.my.foody.domain.user.repo.UserRepository;
+import com.my.foody.global.ex.BusinessException;
+import com.my.foody.global.ex.ErrorCode;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
+@Slf4j
 public class UserService {
     private final UserRepository userRepository;
 
-    public UserSignUpRespDto join(UserSignUpReqDto userSignUpReqDto){
+    public UserSignUpRespDto signUp(UserSignUpReqDto userSignUpReqDto){
         //이메일 중복 검사
-
+        if(userRepository.existsByEmail(userSignUpReqDto.getEmail())){
+            throw new BusinessException(ErrorCode.EMAIL_ALREADY_EXISTS);
+        }
         //닉네임 중복 검사
-
-        //엔티티 전환(비밀번호 인코딩)
-
+        if(userRepository.existsByNickname(userSignUpReqDto.getNickname())){
+            throw new BusinessException(ErrorCode.NICKNAME_ALREADY_EXISTS);
+        }
+        User user = userSignUpReqDto.toEntity();
+        userRepository.save(user);
+        return new UserSignUpRespDto();
     }
 
 }

--- a/src/main/java/com/my/foody/global/ex/ErrorCode.java
+++ b/src/main/java/com/my/foody/global/ex/ErrorCode.java
@@ -13,7 +13,7 @@ public enum ErrorCode {
     MISSING_BEARER_TOKEN(HttpStatus.UNAUTHORIZED.value(), "Bearer 인증 정보가 올바르지 않습니다"),
     FORBIDDEN_ACCESS(HttpStatus.FORBIDDEN.value(), "접근 권한이 없습니다"),
     EMAIL_ALREADY_EXISTS(HttpStatus.CONFLICT.value(), "이미 사용 중인 이메일입니다"),
-    NICKNAME_ALREADY_EXISTS(HttpStatus.CONTINUE.value(), "이미 사용 중인 닉네임입니다");
+    NICKNAME_ALREADY_EXISTS(HttpStatus.CONFLICT.value(), "이미 사용 중인 닉네임입니다");
     ;
 
     private final int status;

--- a/src/main/java/com/my/foody/global/ex/ErrorCode.java
+++ b/src/main/java/com/my/foody/global/ex/ErrorCode.java
@@ -12,6 +12,8 @@ public enum ErrorCode {
     INVALID_TOKEN_FORMAT(HttpStatus.BAD_REQUEST.value(), "잘못된 JWT 토큰입니다"),
     MISSING_BEARER_TOKEN(HttpStatus.UNAUTHORIZED.value(), "Bearer 인증 정보가 올바르지 않습니다"),
     FORBIDDEN_ACCESS(HttpStatus.FORBIDDEN.value(), "접근 권한이 없습니다"),
+    EMAIL_ALREADY_EXISTS(HttpStatus.CONFLICT.value(), "이미 사용 중인 이메일입니다"),
+    NICKNAME_ALREADY_EXISTS(HttpStatus.CONTINUE.value(), "이미 사용 중인 닉네임입니다");
     ;
 
     private final int status;

--- a/src/main/java/com/my/foody/global/util/PasswordEncoder.java
+++ b/src/main/java/com/my/foody/global/util/PasswordEncoder.java
@@ -1,0 +1,18 @@
+package com.my.foody.global.util;
+
+import org.springframework.security.crypto.bcrypt.BCrypt;
+
+public class PasswordEncoder {
+    // 비밀번호 해싱
+    public static String encode(String plainTextPassword) {
+        return BCrypt.hashpw(plainTextPassword, BCrypt.gensalt());
+    }
+
+    //비밀번호 검증
+    public static boolean matches(String plainTextPassword, String hashedPassword) {
+        if (hashedPassword == null || !hashedPassword.startsWith("$2a$")) {
+            return false;
+        }
+        return BCrypt.checkpw(plainTextPassword, hashedPassword);
+    }
+}

--- a/src/main/resources/application-dev.yaml
+++ b/src/main/resources/application-dev.yaml
@@ -15,7 +15,7 @@ spring:
     database-platform: org.hibernate.dialect.MySQL8Dialect
     open-in-view: false
     hibernate:
-      ddl-auto: update
+      ddl-auto: create
     properties:
       '[hibernate.default_batch_fetch_size]': 100
       '[hibernate.format_sql]': true

--- a/src/test/java/com/my/foody/domain/user/service/UserServiceTest.java
+++ b/src/test/java/com/my/foody/domain/user/service/UserServiceTest.java
@@ -31,13 +31,7 @@ class UserServiceTest {
     @Test
     void signup_Success() throws Exception{
         //given
-        UserSignUpReqDto signUpReqDto = UserSignUpReqDto.builder()
-                .contact("010-1234-5678")
-                .email("user1234@naver.com")
-                .password(PasswordEncoder.encode("Password1234!"))
-                .name("userA")
-                .nickname("userrrr")
-                .build();
+        UserSignUpReqDto signUpReqDto = mockUserSignUpReqDto();
 
         when(userRepository.existsByEmail(signUpReqDto.getEmail())).thenReturn(false);
         when(userRepository.existsByNickname(signUpReqDto.getNickname())).thenReturn(false);
@@ -56,13 +50,7 @@ class UserServiceTest {
     @DisplayName(value = "회원가입 실패 테스트: 이메일 중복")
     void signup_EmailAlreadyExists(){
         //given
-        UserSignUpReqDto signUpReqDto = UserSignUpReqDto.builder()
-                .contact("010-1234-5678")
-                .email("user1234@naver.com")
-                .password(PasswordEncoder.encode("Password1234!"))
-                .name("userA")
-                .nickname("userrrr")
-                .build();
+        UserSignUpReqDto signUpReqDto = mockUserSignUpReqDto();
 
         when(userRepository.existsByEmail(signUpReqDto.getEmail())).thenReturn(true);
 
@@ -73,6 +61,34 @@ class UserServiceTest {
         verify(userRepository, times(1)).existsByEmail(signUpReqDto.getEmail());
         verify(userRepository, never()).existsByNickname(signUpReqDto.getNickname());
         verify(userRepository, never()).save(any(User.class));
+    }
+
+    @Test
+    @DisplayName(value = "회원가입 실패 테스트: 닉네임 중복")
+    void signup_NicknameAlreadyExists(){
+        //given
+        UserSignUpReqDto signUpReqDto = mockUserSignUpReqDto();
+
+        when(userRepository.existsByEmail(signUpReqDto.getEmail())).thenReturn(false);
+        when(userRepository.existsByNickname(signUpReqDto.getNickname())).thenReturn(true);
+
+        //then
+        assertThatThrownBy(() -> userService.signUp(signUpReqDto))
+                .isInstanceOf(BusinessException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.NICKNAME_ALREADY_EXISTS);
+        verify(userRepository, times(1)).existsByEmail(signUpReqDto.getEmail());
+        verify(userRepository, times(1)).existsByNickname(signUpReqDto.getNickname());
+        verify(userRepository, never()).save(any(User.class));
+    }
+
+    private UserSignUpReqDto mockUserSignUpReqDto(){
+        return UserSignUpReqDto.builder()
+                .contact("010-1234-5678")
+                .email("user1234@naver.com")
+                .password(PasswordEncoder.encode("Password1234!"))
+                .name("userA")
+                .nickname("userrrr")
+                .build();
     }
 
 }

--- a/src/test/java/com/my/foody/domain/user/service/UserServiceTest.java
+++ b/src/test/java/com/my/foody/domain/user/service/UserServiceTest.java
@@ -4,6 +4,8 @@ import com.my.foody.domain.user.dto.req.UserSignUpReqDto;
 import com.my.foody.domain.user.dto.resp.UserSignUpRespDto;
 import com.my.foody.domain.user.entity.User;
 import com.my.foody.domain.user.repo.UserRepository;
+import com.my.foody.global.ex.BusinessException;
+import com.my.foody.global.ex.ErrorCode;
 import com.my.foody.global.util.PasswordEncoder;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -13,6 +15,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
@@ -26,7 +29,7 @@ class UserServiceTest {
 
     @DisplayName(value = "회원가입 성공 테스트")
     @Test
-    void 회원가입_성공_테스트() throws Exception{
+    void signup_Success() throws Exception{
         //given
         UserSignUpReqDto signUpReqDto = UserSignUpReqDto.builder()
                 .contact("010-1234-5678")
@@ -47,6 +50,29 @@ class UserServiceTest {
         verify(userRepository, times(1)).existsByEmail(signUpReqDto.getEmail());
         verify(userRepository, times(1)).existsByNickname(signUpReqDto.getNickname());
         verify(userRepository, times(1)).save(any(User.class));
+    }
+
+    @Test
+    @DisplayName(value = "회원가입 실패 테스트: 이메일 중복")
+    void signup_EmailAlreadyExists(){
+        //given
+        UserSignUpReqDto signUpReqDto = UserSignUpReqDto.builder()
+                .contact("010-1234-5678")
+                .email("user1234@naver.com")
+                .password(PasswordEncoder.encode("Password1234!"))
+                .name("userA")
+                .nickname("userrrr")
+                .build();
+
+        when(userRepository.existsByEmail(signUpReqDto.getEmail())).thenReturn(true);
+
+        //then
+        assertThatThrownBy(() -> userService.signUp(signUpReqDto))
+                          .isInstanceOf(BusinessException.class)
+                          .hasFieldOrPropertyWithValue("errorCode", ErrorCode.EMAIL_ALREADY_EXISTS);
+        verify(userRepository, times(1)).existsByEmail(signUpReqDto.getEmail());
+        verify(userRepository, never()).existsByNickname(signUpReqDto.getNickname());
+        verify(userRepository, never()).save(any(User.class));
     }
 
 }

--- a/src/test/java/com/my/foody/domain/user/service/UserServiceTest.java
+++ b/src/test/java/com/my/foody/domain/user/service/UserServiceTest.java
@@ -1,0 +1,52 @@
+package com.my.foody.domain.user.service;
+
+import com.my.foody.domain.user.dto.req.UserSignUpReqDto;
+import com.my.foody.domain.user.dto.resp.UserSignUpRespDto;
+import com.my.foody.domain.user.entity.User;
+import com.my.foody.domain.user.repo.UserRepository;
+import com.my.foody.global.util.PasswordEncoder;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class UserServiceTest {
+
+    @Mock
+    private UserRepository userRepository;
+
+    @InjectMocks
+    private UserService userService;
+
+    @DisplayName(value = "회원가입 성공 테스트")
+    @Test
+    void 회원가입_성공_테스트() throws Exception{
+        //given
+        UserSignUpReqDto signUpReqDto = UserSignUpReqDto.builder()
+                .contact("010-1234-5678")
+                .email("user1234@naver.com")
+                .password(PasswordEncoder.encode("Password1234!"))
+                .name("userA")
+                .nickname("userrrr")
+                .build();
+
+        when(userRepository.existsByEmail(signUpReqDto.getEmail())).thenReturn(false);
+        when(userRepository.existsByNickname(signUpReqDto.getNickname())).thenReturn(false);
+
+        //when
+        UserSignUpRespDto result = userService.signUp(signUpReqDto);
+
+        //then
+        assertThat(result.getMessage()).isEqualTo("회원가입 되었습니다");
+        verify(userRepository, times(1)).existsByEmail(signUpReqDto.getEmail());
+        verify(userRepository, times(1)).existsByNickname(signUpReqDto.getNickname());
+        verify(userRepository, times(1)).save(any(User.class));
+    }
+
+}


### PR DESCRIPTION
## 전체 시나리오
1. 클라이언트의 회원가입 요청
2. DTO 유효성 검사 진행 -> 실패 시 유효성 검사 예외 throw
3. 이메일 중복 검사 -> 실패 시 예외 throw
4. 닉네임 중복 검사 -> 실패 시 예외 throw

## 회원가입 단위 테스트 추가
**1. ✅ 회원가입 성공**
  - 이메일, 닉네임 중복 없음
  - 정상적인 회원 저장 검증
 
**2. ❌ 회원가입 실패 케이스**
  - 이메일 중복: EMAIL_ALREADY_EXISTS 예외 발생 검증
  - 닉네임 중복: NICKNAME_ALREADY_EXISTS 예외 발생 검증
  - 각 실패 케이스에서 회원 저장 실행 안됨을 검증

 