### PR TITLE
유저 주소지 등록 기능

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,4 @@ out/
 
 ### VS Code ###
 .vscode/
+application-demo.yaml

--- a/src/main/java/com/my/foody/domain/address/dto/req/AddressCreateReqDto.java
+++ b/src/main/java/com/my/foody/domain/address/dto/req/AddressCreateReqDto.java
@@ -1,4 +1,29 @@
 package com.my.foody.domain.address.dto.req;
 
+import com.my.foody.domain.address.entity.Address;
+import com.my.foody.domain.user.entity.User;
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.validator.constraints.Length;
+
+@NoArgsConstructor
+@Getter
 public class AddressCreateReqDto {
+
+    @NotBlank(message = "도로명 주소를 입력해야 합니다")
+    @Length(min = 1, max = 100, message = "최소 1자에서 최대 100자 사이여야 합니다")
+    private String roadAddress;
+
+    @NotBlank(message = "상세 주소를 입력해야 합니다")
+    @Length(min = 1, max = 30, message = "최소 1자에서 최대 30자 사이여야 합니다")
+    private String detailedAddress;
+
+    public Address toEntity(User user){
+        return Address.builder()
+                .user(user)
+                .detailedAddress(detailedAddress)
+                .roadAddress(roadAddress)
+                .build();
+    }
 }

--- a/src/main/java/com/my/foody/domain/address/dto/req/AddressCreateReqDto.java
+++ b/src/main/java/com/my/foody/domain/address/dto/req/AddressCreateReqDto.java
@@ -3,12 +3,16 @@ package com.my.foody.domain.address.dto.req;
 import com.my.foody.domain.address.entity.Address;
 import com.my.foody.domain.user.entity.User;
 import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.validator.constraints.Length;
 
 @NoArgsConstructor
 @Getter
+@AllArgsConstructor
+@Builder
 public class AddressCreateReqDto {
 
     @NotBlank(message = "도로명 주소를 입력해야 합니다")

--- a/src/main/java/com/my/foody/domain/address/dto/resp/AddressCreateRespDto.java
+++ b/src/main/java/com/my/foody/domain/address/dto/resp/AddressCreateRespDto.java
@@ -1,4 +1,15 @@
 package com.my.foody.domain.address.dto.resp;
 
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
 public class AddressCreateRespDto {
+    private static final String SUCCESS_MESSAGE = "등록 완료 되었습니다";
+    private final String message;
+
+    public AddressCreateRespDto() {
+        this.message = SUCCESS_MESSAGE;
+    }
+
 }

--- a/src/main/java/com/my/foody/domain/address/entity/Address.java
+++ b/src/main/java/com/my/foody/domain/address/entity/Address.java
@@ -4,6 +4,7 @@ import com.my.foody.domain.base.BaseEntity;
 import com.my.foody.domain.user.entity.User;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -25,4 +26,11 @@ public class Address extends BaseEntity {
     @Column(length = 30, nullable = false)
     private String detailedAddress;
 
+    @Builder
+    public Address(Long id, User user, String roadAddress, String detailedAddress) {
+        this.id = id;
+        this.user = user;
+        this.roadAddress = roadAddress;
+        this.detailedAddress = detailedAddress;
+    }
 }

--- a/src/main/java/com/my/foody/domain/user/controller/UserController.java
+++ b/src/main/java/com/my/foody/domain/user/controller/UserController.java
@@ -1,5 +1,7 @@
 package com.my.foody.domain.user.controller;
 
+import com.my.foody.domain.address.dto.req.AddressCreateReqDto;
+import com.my.foody.domain.address.dto.resp.AddressCreateRespDto;
 import com.my.foody.domain.user.dto.req.UserLoginReqDto;
 import com.my.foody.domain.user.dto.req.UserSignUpReqDto;
 import com.my.foody.domain.user.dto.resp.UserInfoRespDto;
@@ -43,6 +45,12 @@ public class UserController {
         return new ResponseEntity<>(ApiResult.success(userService.getUserInfo(tokenSubject.getId())), HttpStatus.OK);
     }
 
+    @RequireAuth(userType = UserType.USER)
+    @PostMapping("/mypage/address")
+    public ResponseEntity<ApiResult<AddressCreateRespDto>> registerAddress(@RequestBody @Valid AddressCreateReqDto addressCreateReqDto,
+                                                                           @CurrentUser TokenSubject tokenSubject){
+        return new ResponseEntity<>(ApiResult.success(userService.registerAddress(addressCreateReqDto, tokenSubject.getId())), HttpStatus.CREATED);
+    }
 
 
 

--- a/src/main/java/com/my/foody/domain/user/service/UserService.java
+++ b/src/main/java/com/my/foody/domain/user/service/UserService.java
@@ -61,12 +61,14 @@ public class UserService {
         return new UserInfoRespDto(user);
     }
 
+
     public AddressCreateRespDto registerAddress(AddressCreateReqDto addressCreateReqDto, Long userId) {
         User user = findByIdOrFail(userId);
         Address address = addressCreateReqDto.toEntity(user);
         addressRepository.save(address);
         return new AddressCreateRespDto();
     }
+
 
     public User findByIdOrFail(Long userId){
         return userRepository.findById(userId)

--- a/src/main/java/com/my/foody/domain/user/service/UserService.java
+++ b/src/main/java/com/my/foody/domain/user/service/UserService.java
@@ -1,6 +1,10 @@
 package com.my.foody.domain.user.service;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.my.foody.domain.address.dto.req.AddressCreateReqDto;
+import com.my.foody.domain.address.dto.resp.AddressCreateRespDto;
+import com.my.foody.domain.address.entity.Address;
+import com.my.foody.domain.address.repo.AddressRepository;
 import com.my.foody.domain.user.dto.req.UserLoginReqDto;
 import com.my.foody.domain.user.dto.req.UserSignUpReqDto;
 import com.my.foody.domain.user.dto.resp.UserInfoRespDto;
@@ -25,6 +29,7 @@ import org.springframework.transaction.annotation.Transactional;
 @Slf4j
 public class UserService {
     private final UserRepository userRepository;
+    private final AddressRepository addressRepository;
     private final JwtProvider jwtProvider;
 
     public UserSignUpRespDto signUp(UserSignUpReqDto userSignUpReqDto){
@@ -52,8 +57,19 @@ public class UserService {
 
 
     public UserInfoRespDto getUserInfo(Long userId) {
+        User user = findByIdOrFail(userId);
+        return new UserInfoRespDto(user);
+    }
+
+    public AddressCreateRespDto registerAddress(AddressCreateReqDto addressCreateReqDto, Long userId) {
+        User user = findByIdOrFail(userId);
+        Address address = addressCreateReqDto.toEntity(user);
+        addressRepository.save(address);
+        return new AddressCreateRespDto();
+    }
+
+    public User findByIdOrFail(Long userId){
         return userRepository.findById(userId)
-                .map(UserInfoRespDto::new)
                 .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
     }
 }

--- a/src/main/java/com/my/foody/global/util/DummyObject.java
+++ b/src/main/java/com/my/foody/global/util/DummyObject.java
@@ -1,5 +1,6 @@
 package com.my.foody.global.util;
 
+import com.my.foody.domain.address.entity.Address;
 import com.my.foody.domain.user.entity.User;
 
 public class DummyObject {
@@ -12,6 +13,15 @@ public class DummyObject {
                 .contact("010-1234-5678")
                 .name("userA")
                 .nickname("userrr")
+                .build();
+    }
+
+
+    protected Address mockAddress(User user){
+        return Address.builder()
+                .user(user)
+                .roadAddress("도로명주소")
+                .detailedAddress("상세주소")
                 .build();
     }
 }

--- a/src/test/java/com/my/foody/domain/user/controller/UserControllerTest.java
+++ b/src/test/java/com/my/foody/domain/user/controller/UserControllerTest.java
@@ -1,6 +1,9 @@
 package com.my.foody.domain.user.controller;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.my.foody.domain.address.dto.req.AddressCreateReqDto;
+import com.my.foody.domain.address.dto.resp.AddressCreateRespDto;
+import com.my.foody.domain.address.entity.Address;
 import com.my.foody.domain.user.dto.resp.UserInfoRespDto;
 import com.my.foody.domain.user.entity.User;
 import com.my.foody.domain.user.service.UserService;
@@ -14,10 +17,12 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 
 import static org.mockito.Mockito.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -67,5 +72,56 @@ public class UserControllerTest extends DummyObject {
                 .andDo(print());
 
         verify(userService, never()).getUserInfo(any());
+    }
+
+    @Test
+    @DisplayName("주소지 등록 성공 테스트")
+    void registerAddress_Success() throws Exception {
+        Long userId = 1L;
+        String token = "test.token";
+        TokenSubject tokenSubject = new TokenSubject(userId, UserType.USER);
+        User user = mockUser();
+        Address address = mockAddress(user);
+        AddressCreateReqDto addressCreateReqDto = AddressCreateReqDto.builder()
+                .roadAddress(address.getRoadAddress())
+                .detailedAddress(address.getDetailedAddress())
+                .build();
+        AddressCreateRespDto result = new AddressCreateRespDto();
+
+        when(jwtProvider.validate(token)).thenReturn(tokenSubject);
+        when(userService.registerAddress(addressCreateReqDto, userId)).thenReturn(result);
+
+        //when & then
+        mvc.perform(post("/api/users/mypage/address")
+                        .header(JwtVo.HEADER, JwtVo.TOKEN_PREFIX + token)
+                        .content(om.writeValueAsString(addressCreateReqDto))
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.success").value(true))
+                .andDo(print());
+    }
+
+    @Test
+    @DisplayName("주소지 등록 실패 테스트: 유효성 검사 실패")
+    void registerAddress_Unauthorized() throws Exception {
+        Long userId = 1L;
+        String token = "test.token";
+        TokenSubject tokenSubject = new TokenSubject(userId, UserType.USER);
+        User user = mockUser();
+        AddressCreateReqDto addressCreateReqDto = AddressCreateReqDto.builder()
+                .roadAddress("")
+                .detailedAddress("")
+                .build();
+        when(jwtProvider.validate(token)).thenReturn(tokenSubject);
+
+        // when & then
+        mvc.perform(post("/api/users/mypage/address")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .header(JwtVo.HEADER, JwtVo.TOKEN_PREFIX+token)
+                        .content(om.writeValueAsString(addressCreateReqDto)))
+                .andExpect(status().isBadRequest())
+                .andDo(print());
+
+        verify(userService, never()).registerAddress(any(), any());
     }
 }


### PR DESCRIPTION
## 전체 시나리오
1. 클라이언트의 주소지 등록 요청
2. DTO 유효성 검사 진행 -> 실패 시 유효성 검사 예외 throw
3. 아이디로 유저 조회 -> 존재하지 않을 시 예외 throw
4. 주소지 db 저장
5. 등록 완료 응답 반환

## 주소지 등록 서비스 단위 테스트 추가
1. ✅ 주소지 등록 성공
    - 정상적인 주소지 등록 케이스 검증
2. ❌ 주소지 실패 
    - 존재하지 않은 사용자의 주소지 생성 시도 시의 예외 검증

## 주소지 등록 컨트롤러 단위 테스트 추가
1. ✅ 주소지 등록 성공
    - 토큰 검증 및 status, response 검증
2. ❌ 주소지 실패 
    - dto 유효성 검사 실패에 따른 검증