### PR TITLE
유저 주소지 삭제 기능

### DIFF
--- a/src/main/java/com/my/foody/domain/address/dto/req/AddressModifyReqDto.java
+++ b/src/main/java/com/my/foody/domain/address/dto/req/AddressModifyReqDto.java
@@ -1,12 +1,16 @@
 package com.my.foody.domain.address.dto.req;
 
 import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.validator.constraints.Length;
 
 @NoArgsConstructor
 @Getter
+@AllArgsConstructor
+@Builder
 public class AddressModifyReqDto {
 
     @Length(min = 1, max = 100, message = "최소 1자에서 최대 100자 사이여야 합니다")

--- a/src/main/java/com/my/foody/domain/address/dto/req/AddressModifyReqDto.java
+++ b/src/main/java/com/my/foody/domain/address/dto/req/AddressModifyReqDto.java
@@ -1,0 +1,17 @@
+package com.my.foody.domain.address.dto.req;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.validator.constraints.Length;
+
+@NoArgsConstructor
+@Getter
+public class AddressModifyReqDto {
+
+    @Length(min = 1, max = 100, message = "최소 1자에서 최대 100자 사이여야 합니다")
+    private String roadAddress;
+
+    @Length(min = 1, max = 30, message = "최소 1자에서 최대 30자 사이여야 합니다")
+    private String detailedAddress;
+}

--- a/src/main/java/com/my/foody/domain/address/dto/resp/AddressModifyRespDto.java
+++ b/src/main/java/com/my/foody/domain/address/dto/resp/AddressModifyRespDto.java
@@ -1,0 +1,15 @@
+package com.my.foody.domain.address.dto.resp;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+
+@Getter
+public class AddressModifyRespDto {
+    private static final String SUCCESS_MESSAGE = "수정 완료 되었습니다";
+    private final String message;
+
+    public AddressModifyRespDto() {
+        this.message = SUCCESS_MESSAGE;
+    }
+}

--- a/src/main/java/com/my/foody/domain/address/entity/Address.java
+++ b/src/main/java/com/my/foody/domain/address/entity/Address.java
@@ -33,4 +33,13 @@ public class Address extends BaseEntity {
         this.roadAddress = roadAddress;
         this.detailedAddress = detailedAddress;
     }
+
+    public void modifyAll(String roadAddress, String detailedAddress){
+        if(!roadAddress.isEmpty()){
+            this.roadAddress = roadAddress;
+        }
+        if(!detailedAddress.isEmpty()){
+            this.detailedAddress = detailedAddress;
+        }
+    }
 }

--- a/src/main/java/com/my/foody/domain/address/entity/Address.java
+++ b/src/main/java/com/my/foody/domain/address/entity/Address.java
@@ -37,6 +37,12 @@ public class Address extends BaseEntity {
     }
 
     public void modifyAll(String roadAddress, String detailedAddress){
+        validateAddress(roadAddress, detailedAddress);
+        this.roadAddress = roadAddress;
+        this.detailedAddress = detailedAddress;
+    }
+
+    private void validateAddress(String roadAddress, String detailedAddress) {
         if(roadAddress == null || roadAddress.trim().isEmpty()) {
             throw new BusinessException(ErrorCode.INVALID_ADDRESS_FORMAT);
         }

--- a/src/main/java/com/my/foody/domain/address/entity/Address.java
+++ b/src/main/java/com/my/foody/domain/address/entity/Address.java
@@ -2,6 +2,8 @@ package com.my.foody.domain.address.entity;
 
 import com.my.foody.domain.base.BaseEntity;
 import com.my.foody.domain.user.entity.User;
+import com.my.foody.global.ex.BusinessException;
+import com.my.foody.global.ex.ErrorCode;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -35,11 +37,18 @@ public class Address extends BaseEntity {
     }
 
     public void modifyAll(String roadAddress, String detailedAddress){
-        if(!roadAddress.isEmpty()){
-            this.roadAddress = roadAddress;
+        if(roadAddress == null || roadAddress.trim().isEmpty()) {
+            throw new BusinessException(ErrorCode.INVALID_ADDRESS_FORMAT);
         }
-        if(!detailedAddress.isEmpty()){
-            this.detailedAddress = detailedAddress;
+        if(detailedAddress == null || detailedAddress.trim().isEmpty()) {
+            throw new BusinessException(ErrorCode.INVALID_ADDRESS_FORMAT);
+        }
+    }
+
+
+    public void validateUser(User user){
+        if(!this.user.getId().equals(user.getId())){
+            throw new BusinessException(ErrorCode.UNAUTHORIZED_ADDRESS_ACCESS);
         }
     }
 }

--- a/src/main/java/com/my/foody/domain/address/service/AddressService.java
+++ b/src/main/java/com/my/foody/domain/address/service/AddressService.java
@@ -1,4 +1,21 @@
 package com.my.foody.domain.address.service;
 
+import com.my.foody.domain.address.entity.Address;
+import com.my.foody.domain.address.repo.AddressRepository;
+import com.my.foody.global.ex.BusinessException;
+import com.my.foody.global.ex.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@RequiredArgsConstructor
+@Service
+@Transactional(readOnly = true)
 public class AddressService {
+    private final AddressRepository addressRepository;
+
+    public Address findByIdOrFail(Long addressId){
+        return addressRepository.findById(addressId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.ADDRESS_NOT_FOUND));
+    }
 }

--- a/src/main/java/com/my/foody/domain/user/controller/UserController.java
+++ b/src/main/java/com/my/foody/domain/user/controller/UserController.java
@@ -6,6 +6,7 @@ import com.my.foody.domain.address.dto.resp.AddressCreateRespDto;
 import com.my.foody.domain.address.dto.resp.AddressModifyRespDto;
 import com.my.foody.domain.user.dto.req.UserLoginReqDto;
 import com.my.foody.domain.user.dto.req.UserSignUpReqDto;
+import com.my.foody.domain.user.dto.resp.AddressDeleteRespDto;
 import com.my.foody.domain.user.dto.resp.UserInfoRespDto;
 import com.my.foody.domain.user.dto.resp.UserLoginRespDto;
 import com.my.foody.domain.user.dto.resp.UserSignUpRespDto;
@@ -60,6 +61,13 @@ public class UserController {
                                                                          @RequestBody @Valid AddressModifyReqDto addressModifyReqDto,
                                                                          @CurrentUser TokenSubject tokenSubject){
         return new ResponseEntity<>(ApiResult.success(userService.modifyAddress(addressModifyReqDto, tokenSubject.getId(), addressId)), HttpStatus.OK);
+    }
+
+    @RequireAuth(userType = UserType.USER)
+    @DeleteMapping("/mypage/address/{addressId}")
+    public ResponseEntity<ApiResult<AddressDeleteRespDto>> deleteAddress(@PathVariable(value = "addressId") Long addressId,
+                                                                         @CurrentUser TokenSubject tokenSubject){
+        return new ResponseEntity<>(ApiResult.success(userService.deleteAddressById(addressId, tokenSubject.getId())), HttpStatus.OK);
     }
 
 

--- a/src/main/java/com/my/foody/domain/user/controller/UserController.java
+++ b/src/main/java/com/my/foody/domain/user/controller/UserController.java
@@ -1,7 +1,9 @@
 package com.my.foody.domain.user.controller;
 
 import com.my.foody.domain.address.dto.req.AddressCreateReqDto;
+import com.my.foody.domain.address.dto.req.AddressModifyReqDto;
 import com.my.foody.domain.address.dto.resp.AddressCreateRespDto;
+import com.my.foody.domain.address.dto.resp.AddressModifyRespDto;
 import com.my.foody.domain.user.dto.req.UserLoginReqDto;
 import com.my.foody.domain.user.dto.req.UserSignUpReqDto;
 import com.my.foody.domain.user.dto.resp.UserInfoRespDto;
@@ -50,6 +52,14 @@ public class UserController {
     public ResponseEntity<ApiResult<AddressCreateRespDto>> registerAddress(@RequestBody @Valid AddressCreateReqDto addressCreateReqDto,
                                                                            @CurrentUser TokenSubject tokenSubject){
         return new ResponseEntity<>(ApiResult.success(userService.registerAddress(addressCreateReqDto, tokenSubject.getId())), HttpStatus.CREATED);
+    }
+
+    @RequireAuth(userType = UserType.USER)
+    @PutMapping("/mypage/address/{addressId}")
+    public ResponseEntity<ApiResult<AddressModifyRespDto>> modifyAddress(@PathVariable(value = "addressId") Long addressId,
+                                                                         @RequestBody @Valid AddressModifyReqDto addressModifyReqDto,
+                                                                         @CurrentUser TokenSubject tokenSubject){
+        return new ResponseEntity<>(ApiResult.success(userService.modifyAddress(addressModifyReqDto, tokenSubject.getId(), addressId)), HttpStatus.OK);
     }
 
 

--- a/src/main/java/com/my/foody/domain/user/dto/resp/AddressDeleteRespDto.java
+++ b/src/main/java/com/my/foody/domain/user/dto/resp/AddressDeleteRespDto.java
@@ -1,0 +1,2 @@
+package com.my.foody.domain.user.dto.resp;public class AddressDeleteRespDto {
+}

--- a/src/main/java/com/my/foody/domain/user/dto/resp/AddressDeleteRespDto.java
+++ b/src/main/java/com/my/foody/domain/user/dto/resp/AddressDeleteRespDto.java
@@ -1,2 +1,15 @@
-package com.my.foody.domain.user.dto.resp;public class AddressDeleteRespDto {
+package com.my.foody.domain.user.dto.resp;
+
+import lombok.Getter;
+
+
+@Getter
+public class AddressDeleteRespDto {
+
+    private static final String SUCCESS_MESSAGE = "삭제 완료 되었습니다";
+    private final String message;
+
+    public AddressDeleteRespDto() {
+        this.message = SUCCESS_MESSAGE;
+    }
 }

--- a/src/main/java/com/my/foody/domain/user/service/UserService.java
+++ b/src/main/java/com/my/foody/domain/user/service/UserService.java
@@ -10,6 +10,7 @@ import com.my.foody.domain.address.repo.AddressRepository;
 import com.my.foody.domain.address.service.AddressService;
 import com.my.foody.domain.user.dto.req.UserLoginReqDto;
 import com.my.foody.domain.user.dto.req.UserSignUpReqDto;
+import com.my.foody.domain.user.dto.resp.AddressDeleteRespDto;
 import com.my.foody.domain.user.dto.resp.UserInfoRespDto;
 import com.my.foody.domain.user.dto.resp.UserLoginRespDto;
 import com.my.foody.domain.user.dto.resp.UserSignUpRespDto;
@@ -19,6 +20,7 @@ import com.my.foody.global.ex.BusinessException;
 import com.my.foody.global.ex.ErrorCode;
 import com.my.foody.global.jwt.JwtProvider;
 import com.my.foody.global.jwt.TokenSubject;
+import jakarta.transaction.TransactionScoped;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.RequiredArgsConstructor;
@@ -79,6 +81,7 @@ public class UserService {
                 .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
     }
 
+
     @Transactional
     public AddressModifyRespDto modifyAddress(AddressModifyReqDto addressModifyReqDto, Long userId, Long addressId) {
         User user = findByIdOrFail(userId);
@@ -89,4 +92,12 @@ public class UserService {
     }
 
 
+    @Transactional
+    public AddressDeleteRespDto deleteAddressById(Long addressId, Long userId) {
+        User user = findByIdOrFail(userId);
+        Address address = addressService.findByIdOrFail(addressId);
+        address.validateUser(user);
+        addressRepository.delete(address);
+        return new AddressDeleteRespDto();
+    }
 }

--- a/src/main/java/com/my/foody/domain/user/service/UserService.java
+++ b/src/main/java/com/my/foody/domain/user/service/UserService.java
@@ -81,8 +81,9 @@ public class UserService {
 
     @Transactional
     public AddressModifyRespDto modifyAddress(AddressModifyReqDto addressModifyReqDto, Long userId, Long addressId) {
-        findByIdOrFail(userId);
+        User user = findByIdOrFail(userId);
         Address address = addressService.findByIdOrFail(addressId);
+        address.validateUser(user);
         address.modifyAll(addressModifyReqDto.getRoadAddress(), addressModifyReqDto.getDetailedAddress());
         return new AddressModifyRespDto();
     }

--- a/src/main/java/com/my/foody/domain/user/service/UserService.java
+++ b/src/main/java/com/my/foody/domain/user/service/UserService.java
@@ -2,9 +2,12 @@ package com.my.foody.domain.user.service;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.my.foody.domain.address.dto.req.AddressCreateReqDto;
+import com.my.foody.domain.address.dto.req.AddressModifyReqDto;
 import com.my.foody.domain.address.dto.resp.AddressCreateRespDto;
+import com.my.foody.domain.address.dto.resp.AddressModifyRespDto;
 import com.my.foody.domain.address.entity.Address;
 import com.my.foody.domain.address.repo.AddressRepository;
+import com.my.foody.domain.address.service.AddressService;
 import com.my.foody.domain.user.dto.req.UserLoginReqDto;
 import com.my.foody.domain.user.dto.req.UserSignUpReqDto;
 import com.my.foody.domain.user.dto.resp.UserInfoRespDto;
@@ -30,6 +33,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class UserService {
     private final UserRepository userRepository;
     private final AddressRepository addressRepository;
+    private final AddressService addressService;
     private final JwtProvider jwtProvider;
 
     public UserSignUpRespDto signUp(UserSignUpReqDto userSignUpReqDto){
@@ -74,4 +78,14 @@ public class UserService {
         return userRepository.findById(userId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
     }
+
+    @Transactional
+    public AddressModifyRespDto modifyAddress(AddressModifyReqDto addressModifyReqDto, Long userId, Long addressId) {
+        findByIdOrFail(userId);
+        Address address = addressService.findByIdOrFail(addressId);
+        address.modifyAll(addressModifyReqDto.getRoadAddress(), addressModifyReqDto.getDetailedAddress());
+        return new AddressModifyRespDto();
+    }
+
+
 }

--- a/src/main/java/com/my/foody/global/ex/ErrorCode.java
+++ b/src/main/java/com/my/foody/global/ex/ErrorCode.java
@@ -18,7 +18,8 @@ public enum ErrorCode {
     INVALID_PASSWORD(HttpStatus.BAD_REQUEST.value(), "비밀번호가 일치하지 않습니다"),
     INVALID_TOKEN(HttpStatus.UNAUTHORIZED.value(), "유효하지 않은 인증 정보 입니다"),
     ADDRESS_NOT_FOUND(HttpStatus.NOT_FOUND.value(), "존재하지 않는 주소지입니다"),
-    ;
+    UNAUTHORIZED_ADDRESS_ACCESS(HttpStatus.UNAUTHORIZED.value(), "해당 주소지에 접근 권한이 없습니다"),
+    INVALID_ADDRESS_FORMAT(HttpStatus.BAD_REQUEST.value(), "유효하지 않은 주소 형식입니다");
 
     private final int status;
     private final String msg;

--- a/src/main/java/com/my/foody/global/ex/ErrorCode.java
+++ b/src/main/java/com/my/foody/global/ex/ErrorCode.java
@@ -17,6 +17,7 @@ public enum ErrorCode {
     USER_NOT_FOUND(HttpStatus.NOT_FOUND.value(), "존재하지 않는 유저입니다"),
     INVALID_PASSWORD(HttpStatus.BAD_REQUEST.value(), "비밀번호가 일치하지 않습니다"),
     INVALID_TOKEN(HttpStatus.UNAUTHORIZED.value(), "유효하지 않은 인증 정보 입니다"),
+    ADDRESS_NOT_FOUND(HttpStatus.NOT_FOUND.value(), "존재하지 않는 주소지입니다"),
     ;
 
     private final int status;

--- a/src/main/java/com/my/foody/global/util/DummyObject.java
+++ b/src/main/java/com/my/foody/global/util/DummyObject.java
@@ -5,6 +5,18 @@ import com.my.foody.domain.user.entity.User;
 
 public class DummyObject {
 
+    protected User newUser(Long id){
+        String password = "Maeda1234!";
+        return User.builder()
+                .email("user1234@naver.com")
+                .id(id)
+                .password(PasswordEncoder.encode(password))
+                .contact("010-1234-5678")
+                .name("userA")
+                .nickname("userrr")
+                .build();
+    }
+
     protected User mockUser(){
         String password = "Maeda1234!";
         return User.builder()

--- a/src/test/java/com/my/foody/domain/user/service/UserServiceTest.java
+++ b/src/test/java/com/my/foody/domain/user/service/UserServiceTest.java
@@ -309,7 +309,7 @@ class UserServiceTest extends DummyObject {
                 .isInstanceOf(BusinessException.class)
                 .hasFieldOrPropertyWithValue("errorCode", ErrorCode.ADDRESS_NOT_FOUND);
         verify(userRepository).findById(userId);
-        verify(addressService).findByIdOrFail(addressId);ad
+        verify(addressService).findByIdOrFail(addressId);
     }
 
 

--- a/src/test/java/com/my/foody/domain/user/service/UserServiceTest.java
+++ b/src/test/java/com/my/foody/domain/user/service/UserServiceTest.java
@@ -251,14 +251,13 @@ class UserServiceTest extends DummyObject {
     void modifyAddress_Success(){
         Long userId = 1L;
         Long addressId = 1L;
-        User user = mockUser();
+        User user = newUser(userId);
         Address address = mockAddress(user);
 
         AddressModifyReqDto modifyReqDto = AddressModifyReqDto.builder()
                 .roadAddress("새로운 도로명주소")
                 .detailedAddress("새로운 상세주소")
                 .build();
-
         when(userRepository.findById(userId)).thenReturn(Optional.of(user));
         when(addressService.findByIdOrFail(addressId)).thenReturn(address);
 
@@ -267,8 +266,6 @@ class UserServiceTest extends DummyObject {
 
         // then
         assertNotNull(result);
-        assertEquals("새로운 도로명주소", address.getRoadAddress());
-        assertEquals("새로운 상세주소", address.getDetailedAddress());
         verify(userRepository).findById(userId);
         verify(addressService).findByIdOrFail(addressId);
     }
@@ -278,6 +275,7 @@ class UserServiceTest extends DummyObject {
     void modifyAddress_UserNotFound() {
         Long userId = 1L;
         Long addressId = 1L;
+        User user = newUser(userId);
 
         AddressModifyReqDto modifyReqDto = AddressModifyReqDto.builder()
                 .roadAddress("새로운 도로명주소")
@@ -290,6 +288,28 @@ class UserServiceTest extends DummyObject {
                 .hasFieldOrPropertyWithValue("errorCode", ErrorCode.USER_NOT_FOUND);
         verify(userRepository).findById(userId);
         verify(addressService, never()).findByIdOrFail(anyLong());
+    }
+
+    @Test
+    @DisplayName("주소지 수정 실패 테스트: 존재하지 않는 주소지")
+    void modifyAddress_AddressNotFound() {
+        Long userId = 1L;
+        Long addressId = 1L;
+        User user = newUser(userId);
+
+        AddressModifyReqDto modifyReqDto = AddressModifyReqDto.builder()
+                .roadAddress("새로운 도로명주소")
+                .detailedAddress("새로운 상세주소")
+                .build();
+        when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+        when(addressService.findByIdOrFail(addressId))
+                .thenThrow(new BusinessException(ErrorCode.ADDRESS_NOT_FOUND));
+
+        assertThatThrownBy(() -> userService.modifyAddress(modifyReqDto, userId, addressId))
+                .isInstanceOf(BusinessException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.ADDRESS_NOT_FOUND);
+        verify(userRepository).findById(userId);
+        verify(addressService).findByIdOrFail(addressId);ad
     }
 
 

--- a/src/test/java/com/my/foody/domain/user/service/UserServiceTest.java
+++ b/src/test/java/com/my/foody/domain/user/service/UserServiceTest.java
@@ -1,9 +1,12 @@
 package com.my.foody.domain.user.service;
 
 import com.my.foody.domain.address.dto.req.AddressCreateReqDto;
+import com.my.foody.domain.address.dto.req.AddressModifyReqDto;
 import com.my.foody.domain.address.dto.resp.AddressCreateRespDto;
+import com.my.foody.domain.address.dto.resp.AddressModifyRespDto;
 import com.my.foody.domain.address.entity.Address;
 import com.my.foody.domain.address.repo.AddressRepository;
+import com.my.foody.domain.address.service.AddressService;
 import com.my.foody.domain.user.dto.req.UserLoginReqDto;
 import com.my.foody.domain.user.dto.req.UserSignUpReqDto;
 import com.my.foody.domain.user.dto.resp.UserInfoRespDto;
@@ -28,7 +31,7 @@ import java.util.Optional;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
@@ -38,6 +41,10 @@ class UserServiceTest extends DummyObject {
     private UserRepository userRepository;
     @Mock
     private JwtProvider jwtProvider;
+
+    @Mock
+    private AddressService addressService;
+
 
     @InjectMocks
     private UserService userService;
@@ -237,6 +244,52 @@ class UserServiceTest extends DummyObject {
         );
         verify(userRepository, times(1)).findById(userId);
         verify(addressRepository, never()).save(any(Address.class));
+    }
+
+    @Test
+    @DisplayName("주소지 수정 성공 테스트")
+    void modifyAddress_Success(){
+        Long userId = 1L;
+        Long addressId = 1L;
+        User user = mockUser();
+        Address address = mockAddress(user);
+
+        AddressModifyReqDto modifyReqDto = AddressModifyReqDto.builder()
+                .roadAddress("새로운 도로명주소")
+                .detailedAddress("새로운 상세주소")
+                .build();
+
+        when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+        when(addressService.findByIdOrFail(addressId)).thenReturn(address);
+
+        // when
+        AddressModifyRespDto result = userService.modifyAddress(modifyReqDto, userId, addressId);
+
+        // then
+        assertNotNull(result);
+        assertEquals("새로운 도로명주소", address.getRoadAddress());
+        assertEquals("새로운 상세주소", address.getDetailedAddress());
+        verify(userRepository).findById(userId);
+        verify(addressService).findByIdOrFail(addressId);
+    }
+
+    @Test
+    @DisplayName("주소지 수정 실패 테스트: 존재하지 않는 사용자")
+    void modifyAddress_UserNotFound() {
+        Long userId = 1L;
+        Long addressId = 1L;
+
+        AddressModifyReqDto modifyReqDto = AddressModifyReqDto.builder()
+                .roadAddress("새로운 도로명주소")
+                .detailedAddress("새로운 상세주소")
+                .build();
+        when(userRepository.findById(userId)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> userService.modifyAddress(modifyReqDto, userId, addressId))
+                .isInstanceOf(BusinessException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.USER_NOT_FOUND);
+        verify(userRepository).findById(userId);
+        verify(addressService, never()).findByIdOrFail(anyLong());
     }
 
 

--- a/src/test/java/com/my/foody/domain/user/service/UserServiceTest.java
+++ b/src/test/java/com/my/foody/domain/user/service/UserServiceTest.java
@@ -9,6 +9,7 @@ import com.my.foody.domain.address.repo.AddressRepository;
 import com.my.foody.domain.address.service.AddressService;
 import com.my.foody.domain.user.dto.req.UserLoginReqDto;
 import com.my.foody.domain.user.dto.req.UserSignUpReqDto;
+import com.my.foody.domain.user.dto.resp.AddressDeleteRespDto;
 import com.my.foody.domain.user.dto.resp.UserInfoRespDto;
 import com.my.foody.domain.user.dto.resp.UserLoginRespDto;
 import com.my.foody.domain.user.dto.resp.UserSignUpRespDto;
@@ -312,6 +313,88 @@ class UserServiceTest extends DummyObject {
         verify(addressService).findByIdOrFail(addressId);
     }
 
+    @Test
+    @DisplayName("주소지 삭제 성공 테스트")
+    void deleteAddressById_Success(){
+        Long userId = 1L;
+        Long addressId = 1L;
+        User user = newUser(userId);
+        Address address = mockAddress(user);
+
+        when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+        when(addressService.findByIdOrFail(addressId)).thenReturn(address);
+        doNothing().when(addressRepository).delete(address);
+
+        AddressDeleteRespDto result = userService.deleteAddressById(addressId, userId);
+
+        assertNotNull(result);
+        verify(userRepository).findById(userId);
+        verify(addressService).findByIdOrFail(addressId);
+        verify(addressRepository).delete(address);
+    }
+
+    @Test
+    @DisplayName("주소지 삭제 실패 테스트: 존재하지 않는 사용자")
+    void deleteAddressById_UserNotFound() {
+        Long userId = 1111L;
+        Long addressId = 1L;
+
+        when(userRepository.findById(userId)).thenReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> userService.deleteAddressById(addressId, userId))
+                .isInstanceOf(BusinessException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.USER_NOT_FOUND);
+
+        verify(userRepository).findById(userId);
+        verify(addressService, never()).findByIdOrFail(anyLong());
+        verify(addressRepository, never()).delete(any(Address.class));
+    }
+
+    @Test
+    @DisplayName("주소지 삭제 실패 테스트: 존재하지 않는 주소")
+    void deleteAddressById_AddressNotFound() {
+        Long userId = 1L;
+        Long addressId = 999L;
+        User user = newUser(userId);
+
+        when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+        when(addressService.findByIdOrFail(addressId))
+                .thenThrow(new BusinessException(ErrorCode.ADDRESS_NOT_FOUND));
+
+        // when & then
+        assertThatThrownBy(() -> userService.deleteAddressById(addressId, userId))
+                .isInstanceOf(BusinessException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.ADDRESS_NOT_FOUND);
+
+        verify(userRepository).findById(userId);
+        verify(addressService).findByIdOrFail(addressId);
+        verify(addressRepository, never()).delete(any(Address.class));
+    }
+
+    @Test
+    @DisplayName("주소지 삭제 실패 테스트: 다른 사용자의 주소")
+    void deleteAddressById_UnauthorizedUser() {
+        Long userId = 1L;
+        Long addressId = 1L;
+        Long otherUserId = 2L;
+
+        User user = newUser(userId);
+        User otherUser = newUser(otherUserId);
+        Address address = mockAddress(otherUser);
+
+        when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+        when(addressService.findByIdOrFail(addressId)).thenReturn(address);
+
+        // when & then
+        assertThatThrownBy(() -> userService.deleteAddressById(addressId, userId))
+                .isInstanceOf(BusinessException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.UNAUTHORIZED_ADDRESS_ACCESS);
+
+        verify(userRepository).findById(userId);
+        verify(addressService).findByIdOrFail(addressId);
+        verify(addressRepository, never()).delete(any(Address.class));
+    }
 
     private UserSignUpReqDto mockUserSignUpReqDto(){
         return UserSignUpReqDto.builder()


### PR DESCRIPTION
## 전체 시나리오
1. 클라이언트의 주소지 삭제 요청
2. 아이디로 유저 조회 -> 존재하지 않을 시 예외 throw
3. 주소지 조회 -> 존재하지 않을 시 예외 throw
4. 해당 주소지 작성자가 앞서 조회한 유저가 맞는지 검증 -> 불일치시 예외 throw
5. 삭제
7. 삭제 완료 응답 반환

## 주소지 삭제  단위 테스트 추가
1. ✅ 주소지 삭제 성공
    - 정상적인 주소지 삭제 케이스 검증
2. ❌ 주소지 삭제 실패 케이스
    - 존재하지 않는 사용자: USER_NOT_FOUND 검증
    - 존재하지 않는 주소지: ADDRESS_NOT_FOUND 검증
    - 다른 사용자의 주소지를 삭제하는 경우: UNAUTHORIZED_ADDRESS_ACCESS 검증