### PR TITLE
유저 전체 주소지 조회 기능

### DIFF
--- a/src/main/java/com/my/foody/domain/address/repo/AddressRepository.java
+++ b/src/main/java/com/my/foody/domain/address/repo/AddressRepository.java
@@ -1,9 +1,14 @@
 package com.my.foody.domain.address.repo;
 
 import com.my.foody.domain.address.entity.Address;
+import com.my.foody.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
+
+import java.util.List;
 
 @Repository
 public interface AddressRepository extends JpaRepository<Address, Long> {
+    List<Address> findAllByUser(User user);
 }

--- a/src/main/java/com/my/foody/domain/address/repo/AddressRepository.java
+++ b/src/main/java/com/my/foody/domain/address/repo/AddressRepository.java
@@ -10,5 +10,5 @@ import java.util.List;
 
 @Repository
 public interface AddressRepository extends JpaRepository<Address, Long> {
-    List<Address> findAllByUser(User user);
+    List<Address> findAllByUserOrderByCreatedAtDesc(User user);
 }

--- a/src/main/java/com/my/foody/domain/user/controller/UserController.java
+++ b/src/main/java/com/my/foody/domain/user/controller/UserController.java
@@ -6,10 +6,7 @@ import com.my.foody.domain.address.dto.resp.AddressCreateRespDto;
 import com.my.foody.domain.address.dto.resp.AddressModifyRespDto;
 import com.my.foody.domain.user.dto.req.UserLoginReqDto;
 import com.my.foody.domain.user.dto.req.UserSignUpReqDto;
-import com.my.foody.domain.user.dto.resp.AddressDeleteRespDto;
-import com.my.foody.domain.user.dto.resp.UserInfoRespDto;
-import com.my.foody.domain.user.dto.resp.UserLoginRespDto;
-import com.my.foody.domain.user.dto.resp.UserSignUpRespDto;
+import com.my.foody.domain.user.dto.resp.*;
 import com.my.foody.domain.user.service.UserService;
 import com.my.foody.global.config.valid.CurrentUser;
 import com.my.foody.global.config.valid.RequireAuth;
@@ -70,6 +67,12 @@ public class UserController {
         return new ResponseEntity<>(ApiResult.success(userService.deleteAddressById(addressId, tokenSubject.getId())), HttpStatus.OK);
     }
 
+
+    @RequireAuth(userType = UserType.USER)
+    @GetMapping("/mypage/address")
+    public ResponseEntity<ApiResult<AddressListRespDto>> getAllAddress(@CurrentUser TokenSubject tokenSubject){
+        return new ResponseEntity<>(ApiResult.success(userService.getAllAddress(tokenSubject.getId())), HttpStatus.OK);
+    }
 
 
 }

--- a/src/main/java/com/my/foody/domain/user/dto/resp/AddressListRespDto.java
+++ b/src/main/java/com/my/foody/domain/user/dto/resp/AddressListRespDto.java
@@ -1,0 +1,36 @@
+package com.my.foody.domain.user.dto.resp;
+
+import com.my.foody.domain.address.entity.Address;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.sql.Array;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@NoArgsConstructor
+@Getter
+public class AddressListRespDto {
+    private List<AddressRespDto> addressList;
+
+    public AddressListRespDto(List<Address> addressList) {
+        this.addressList = addressList.stream()
+                .map(AddressRespDto::new)
+                .collect(Collectors.toList());
+    }
+
+    @NoArgsConstructor
+    @Getter
+    public static class AddressRespDto{
+        public AddressRespDto(Address address) {
+            this.addressId = address.getId();
+            this.roadAddress = address.getRoadAddress();
+            this.detailedAddress = address.getDetailedAddress();
+        }
+
+        private Long addressId;
+        private String roadAddress;
+        private String detailedAddress;
+    }
+}

--- a/src/main/java/com/my/foody/domain/user/service/UserService.java
+++ b/src/main/java/com/my/foody/domain/user/service/UserService.java
@@ -99,7 +99,7 @@ public class UserService {
 
     public AddressListRespDto getAllAddress(Long userId) {
         User user = findByIdOrFail(userId);
-        List<Address> addressList = addressRepository.findAllByUser(user);
+        List<Address> addressList = addressRepository.findAllByUserOrderByCreatedAtDesc(user);
         return new AddressListRespDto(addressList);
     }
 }

--- a/src/main/java/com/my/foody/domain/user/service/UserService.java
+++ b/src/main/java/com/my/foody/domain/user/service/UserService.java
@@ -1,6 +1,5 @@
 package com.my.foody.domain.user.service;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.my.foody.domain.address.dto.req.AddressCreateReqDto;
 import com.my.foody.domain.address.dto.req.AddressModifyReqDto;
 import com.my.foody.domain.address.dto.resp.AddressCreateRespDto;
@@ -10,23 +9,19 @@ import com.my.foody.domain.address.repo.AddressRepository;
 import com.my.foody.domain.address.service.AddressService;
 import com.my.foody.domain.user.dto.req.UserLoginReqDto;
 import com.my.foody.domain.user.dto.req.UserSignUpReqDto;
-import com.my.foody.domain.user.dto.resp.AddressDeleteRespDto;
-import com.my.foody.domain.user.dto.resp.UserInfoRespDto;
-import com.my.foody.domain.user.dto.resp.UserLoginRespDto;
-import com.my.foody.domain.user.dto.resp.UserSignUpRespDto;
+import com.my.foody.domain.user.dto.resp.*;
 import com.my.foody.domain.user.entity.User;
 import com.my.foody.domain.user.repo.UserRepository;
 import com.my.foody.global.ex.BusinessException;
 import com.my.foody.global.ex.ErrorCode;
 import com.my.foody.global.jwt.JwtProvider;
 import com.my.foody.global.jwt.TokenSubject;
-import jakarta.transaction.TransactionScoped;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -99,5 +94,12 @@ public class UserService {
         address.validateUser(user);
         addressRepository.delete(address);
         return new AddressDeleteRespDto();
+    }
+
+
+    public AddressListRespDto getAllAddress(Long userId) {
+        User user = findByIdOrFail(userId);
+        List<Address> addressList = addressRepository.findAllByUser(user);
+        return new AddressListRespDto(addressList);
     }
 }

--- a/src/test/java/com/my/foody/domain/user/controller/UserControllerTest.java
+++ b/src/test/java/com/my/foody/domain/user/controller/UserControllerTest.java
@@ -4,14 +4,17 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.my.foody.domain.address.dto.req.AddressCreateReqDto;
 import com.my.foody.domain.address.dto.resp.AddressCreateRespDto;
 import com.my.foody.domain.address.entity.Address;
+import com.my.foody.domain.user.dto.resp.AddressListRespDto;
 import com.my.foody.domain.user.dto.resp.UserInfoRespDto;
 import com.my.foody.domain.user.entity.User;
 import com.my.foody.domain.user.service.UserService;
+import com.my.foody.global.ex.BusinessException;
 import com.my.foody.global.jwt.JwtProvider;
 import com.my.foody.global.jwt.JwtVo;
 import com.my.foody.global.jwt.TokenSubject;
 import com.my.foody.global.jwt.UserType;
 import com.my.foody.global.util.DummyObject;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -20,6 +23,10 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.hamcrest.Matchers.hasSize;
 import static org.mockito.Mockito.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
@@ -123,5 +130,58 @@ public class UserControllerTest extends DummyObject {
                 .andDo(print());
 
         verify(userService, never()).registerAddress(any(), any());
+    }
+
+    @Test
+    @DisplayName("전체 주소지 조회 성공 테스트: 주소지 크기 5")
+    void getAllAddress_Success() throws Exception {
+        Long userId = 1L;
+        String token = "test.token";
+        TokenSubject tokenSubject = new TokenSubject(userId, UserType.USER);
+        User user = mockUser();
+
+        List<Address> addressList = new ArrayList<>();
+        for(int i = 0;i<5;i++){
+            addressList.add(mockAddress(user));
+        }
+
+        AddressListRespDto result = new AddressListRespDto(addressList);
+        
+        when(jwtProvider.validate(token)).thenReturn(tokenSubject);
+        when(userService.getAllAddress(userId)).thenReturn(result);
+
+        //when & then
+        mvc.perform(get("/api/users/mypage/address")
+                        .header(JwtVo.HEADER, JwtVo.TOKEN_PREFIX + token))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.addressList").isArray())
+                .andExpect(jsonPath("$.data.addressList", hasSize(addressList.size())))
+                .andExpect(jsonPath("$.data.addressList[0].roadAddress").exists())
+                .andExpect(jsonPath("$.data.addressList[0].detailedAddress").exists())
+                .andDo(print());
+    }
+
+    @Test
+    @DisplayName("전체 주소지 조회 성공 테스트: 빈 주소 목록")
+    void getAllAddress_EmptyList() throws Exception {
+        Long userId = 1L;
+        String token = "test.token";
+        TokenSubject tokenSubject = new TokenSubject(userId, UserType.USER);
+
+        AddressListRespDto result = new AddressListRespDto(new ArrayList<>());
+
+        when(jwtProvider.validate(token)).thenReturn(tokenSubject);
+        when(userService.getAllAddress(userId)).thenReturn(result);
+
+        // when & then
+        mvc.perform(get("/api/users/mypage/address")
+                        .header(JwtVo.HEADER, JwtVo.TOKEN_PREFIX + token)
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.addressList").isArray())
+                .andExpect(jsonPath("$.data.addressList", hasSize(0)))
+                .andDo(print());
     }
 }

--- a/src/test/java/com/my/foody/domain/user/service/UserServiceTest.java
+++ b/src/test/java/com/my/foody/domain/user/service/UserServiceTest.java
@@ -418,6 +418,20 @@ class UserServiceTest extends DummyObject {
         verify(addressRepository).findAllByUser(user);
     }
 
+    @Test
+    @DisplayName(value = "전체 주소지 조회 실패 테스트: 존재하지 않는 유저")
+    void getAllAddress_UserNotFound(){
+        Long userId = 1L;
+        when(userRepository.findById(userId)).thenReturn(Optional.empty());
+
+        //when & then
+        assertThatThrownBy(() -> userService.getAllAddress(userId))
+                .isInstanceOf(BusinessException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.USER_NOT_FOUND);
+        verify(userRepository, times(1)).findById(userId);
+        verify(addressRepository, never()).findAllByUser(any(User.class));
+    }
+
     private UserSignUpReqDto mockUserSignUpReqDto(){
         return UserSignUpReqDto.builder()
                 .contact("010-1234-5678")

--- a/src/test/java/com/my/foody/domain/user/service/UserServiceTest.java
+++ b/src/test/java/com/my/foody/domain/user/service/UserServiceTest.java
@@ -9,10 +9,7 @@ import com.my.foody.domain.address.repo.AddressRepository;
 import com.my.foody.domain.address.service.AddressService;
 import com.my.foody.domain.user.dto.req.UserLoginReqDto;
 import com.my.foody.domain.user.dto.req.UserSignUpReqDto;
-import com.my.foody.domain.user.dto.resp.AddressDeleteRespDto;
-import com.my.foody.domain.user.dto.resp.UserInfoRespDto;
-import com.my.foody.domain.user.dto.resp.UserLoginRespDto;
-import com.my.foody.domain.user.dto.resp.UserSignUpRespDto;
+import com.my.foody.domain.user.dto.resp.*;
 import com.my.foody.domain.user.entity.User;
 import com.my.foody.domain.user.repo.UserRepository;
 import com.my.foody.global.ex.BusinessException;
@@ -28,6 +25,8 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Optional;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
@@ -394,6 +393,29 @@ class UserServiceTest extends DummyObject {
         verify(userRepository).findById(userId);
         verify(addressService).findByIdOrFail(addressId);
         verify(addressRepository, never()).delete(any(Address.class));
+    }
+
+    @Test
+    @DisplayName(value = "전체 주소지 조회 성공 테스트")
+    void getAllAddress_Success(){
+        Long userId = 1L;
+        User user = newUser(userId);
+        List<Address> addressList = new ArrayList<>();
+        for(int i = 0;i<5;i++){
+            addressList.add(mockAddress(user));
+        }
+
+        when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+        when(addressRepository.findAllByUser(user)).thenReturn(addressList);
+
+        //when
+        AddressListRespDto result = userService.getAllAddress(userId);
+
+        //then
+        assertNotNull(result);
+        assertThat(result.getAddressList().size()).isEqualTo(addressList.size());
+        verify(userRepository).findById(userId);
+        verify(addressRepository).findAllByUser(user);
     }
 
     private UserSignUpReqDto mockUserSignUpReqDto(){

--- a/src/test/java/com/my/foody/domain/user/service/UserServiceTest.java
+++ b/src/test/java/com/my/foody/domain/user/service/UserServiceTest.java
@@ -406,7 +406,7 @@ class UserServiceTest extends DummyObject {
         }
 
         when(userRepository.findById(userId)).thenReturn(Optional.of(user));
-        when(addressRepository.findAllByUser(user)).thenReturn(addressList);
+        when(addressRepository.findAllByUserOrderByCreatedAtDesc(user)).thenReturn(addressList);
 
         //when
         AddressListRespDto result = userService.getAllAddress(userId);
@@ -415,7 +415,7 @@ class UserServiceTest extends DummyObject {
         assertNotNull(result);
         assertThat(result.getAddressList().size()).isEqualTo(addressList.size());
         verify(userRepository).findById(userId);
-        verify(addressRepository).findAllByUser(user);
+        verify(addressRepository).findAllByUserOrderByCreatedAtDesc(user);
     }
 
     @Test
@@ -429,7 +429,7 @@ class UserServiceTest extends DummyObject {
                 .isInstanceOf(BusinessException.class)
                 .hasFieldOrPropertyWithValue("errorCode", ErrorCode.USER_NOT_FOUND);
         verify(userRepository, times(1)).findById(userId);
-        verify(addressRepository, never()).findAllByUser(any(User.class));
+        verify(addressRepository, never()).findAllByUserOrderByCreatedAtDesc(any(User.class));
     }
 
     private UserSignUpReqDto mockUserSignUpReqDto(){


### PR DESCRIPTION
## 전체 시나리오
1. 클라이언트가 주소지 전체 조회 요청
2. 토큰 검증
3. 토큰에서 꺼낸 유저 조회 -> 존재하지 않을 시 에러 throw
4. 유저의 모든 주소지 조회 (리스트: id, 도로명 주소, 상세 주소)
5. 응답 반환

## 전체 주소지 조회 단위 테스트 추가
1. ✅ 주소지 조회 성공
    - 정상적인 주소지 수정 케이스 검증
    - 빈 주소 목록 반환 케이스 검증
2. ❌ 주소지 조회 실패 케이스
    - 존재하지 않는 사용자: USER_NOT_FOUND 검증
