### PR TITLE
장바구니 조회 기능 #28

### DIFF
--- a/src/main/java/com/my/foody/domain/cart/controller/CartController.java
+++ b/src/main/java/com/my/foody/domain/cart/controller/CartController.java
@@ -1,6 +1,6 @@
 package com.my.foody.domain.cart.controller;
 
-import com.my.foody.domain.cart.dto.resp.CartCreateRespDto;
+import com.my.foody.domain.cart.dto.resp.CartItemRespDto;
 import com.my.foody.domain.cart.service.CartService;
 import com.my.foody.global.config.valid.CurrentUser;
 import com.my.foody.global.config.valid.RequireAuth;
@@ -24,13 +24,13 @@ public class CartController {
 
     @RequireAuth(userType = UserType.USER) // User 인증 확인
     @GetMapping
-    public ResponseEntity<ApiResult<Page<CartCreateRespDto>>> getCartItems(
+    public ResponseEntity<ApiResult<Page<CartItemRespDto>>> getCartItems(
             @RequestParam int page,
             @RequestParam int limit,
             @CurrentUser TokenSubject tokenSubject) {
 
         Long userId = tokenSubject.getId();
-        Page<CartCreateRespDto> cartItems = cartService.getCartItems(userId, page, limit);
+        Page<CartItemRespDto> cartItems = cartService.getCartItems(userId, page, limit);
 
         return ResponseEntity.ok(ApiResult.success(cartItems));
     }

--- a/src/main/java/com/my/foody/domain/cart/dto/resp/CartItemRespDto.java
+++ b/src/main/java/com/my/foody/domain/cart/dto/resp/CartItemRespDto.java
@@ -9,7 +9,7 @@ import lombok.NoArgsConstructor;
 @Getter
 @AllArgsConstructor
 @Builder
-public class CartCreateRespDto {
+public class CartItemRespDto {
     private String storeName;
     private String menuName;
     private Long menuPrice;

--- a/src/main/java/com/my/foody/domain/cart/service/CartService.java
+++ b/src/main/java/com/my/foody/domain/cart/service/CartService.java
@@ -20,8 +20,8 @@ public class CartService {
 
     public Page<CartItemRespDto> getCartItems(Long userId, int page, int limit) {
 
-        //User의 존재 검증
-        userService.findByIdOrFail(userId);
+        //Active User의 존재 검증
+        userService.findActivateUserByIdOrFail(userId);
 
         Pageable pageable = PageRequest.of(page, limit, Sort.by("id").descending());
         Page<Cart> cartItemsPage = cartRepository.findByUserId(userId, pageable);

--- a/src/main/java/com/my/foody/domain/cart/service/CartService.java
+++ b/src/main/java/com/my/foody/domain/cart/service/CartService.java
@@ -3,6 +3,7 @@ package com.my.foody.domain.cart.service;
 import com.my.foody.domain.cart.dto.resp.CartItemRespDto;
 import com.my.foody.domain.cart.entity.Cart;
 import com.my.foody.domain.cart.repo.CartRepository;
+import com.my.foody.domain.user.service.UserService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
@@ -15,8 +16,13 @@ import org.springframework.stereotype.Service;
 public class CartService {
 
     private final CartRepository cartRepository;
+    private final UserService userService;
 
     public Page<CartItemRespDto> getCartItems(Long userId, int page, int limit) {
+
+        //User의 존재 검증
+        userService.findByIdOrFail(userId);
+
         Pageable pageable = PageRequest.of(page, limit, Sort.by("id").descending());
         Page<Cart> cartItemsPage = cartRepository.findByUserId(userId, pageable);
 

--- a/src/main/java/com/my/foody/domain/cart/service/CartService.java
+++ b/src/main/java/com/my/foody/domain/cart/service/CartService.java
@@ -1,6 +1,6 @@
 package com.my.foody.domain.cart.service;
 
-import com.my.foody.domain.cart.dto.resp.CartCreateRespDto;
+import com.my.foody.domain.cart.dto.resp.CartItemRespDto;
 import com.my.foody.domain.cart.entity.Cart;
 import com.my.foody.domain.cart.repo.CartRepository;
 import lombok.RequiredArgsConstructor;
@@ -16,7 +16,7 @@ public class CartService {
 
     private final CartRepository cartRepository;
 
-    public Page<CartCreateRespDto> getCartItems(Long userId, int page, int limit) {
+    public Page<CartItemRespDto> getCartItems(Long userId, int page, int limit) {
         Pageable pageable = PageRequest.of(page, limit, Sort.by("id").descending());
         Page<Cart> cartItemsPage = cartRepository.findByUserId(userId, pageable);
 
@@ -25,7 +25,7 @@ public class CartService {
           Long totalOrderAmount = cartItem.getMenu().getPrice() * cartItem.getQuantity();
           Long minOrderAmount = cartItem.getStore().getMinOrderAmount();
 
-          return new CartCreateRespDto(
+          return new CartItemRespDto(
               cartItem.getStore().getName(),
               cartItem.getMenu().getName(),
               cartItem.getMenu().getPrice(),

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -1,3 +1,3 @@
 spring:
   profiles:
-    active: test
+    active: dev

--- a/src/test/java/com/my/foody/domain/cart/service/CartServiceTest.java
+++ b/src/test/java/com/my/foody/domain/cart/service/CartServiceTest.java
@@ -3,7 +3,7 @@ package com.my.foody.domain.cart.service;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.*;
 
-import com.my.foody.domain.cart.dto.resp.CartCreateRespDto;
+import com.my.foody.domain.cart.dto.resp.CartItemRespDto;
 import com.my.foody.domain.cart.entity.Cart;
 import com.my.foody.domain.cart.repo.CartRepository;
 import java.util.Arrays;
@@ -66,11 +66,11 @@ public class CartServiceTest {
         when(cartRepository.findByUserId(userId, pageable)).thenReturn(cartItemsPage);
 
         // when
-        Page<CartCreateRespDto> result = cartService.getCartItems(userId, page, limit);
+        Page<CartItemRespDto> result = cartService.getCartItems(userId, page, limit);
 
         // then
         assertEquals(1, result.getTotalElements());
-        CartCreateRespDto cartDto = result.getContent().get(0);
+        CartItemRespDto cartDto = result.getContent().get(0);
 
         assertEquals("Test 음식점", cartDto.getStoreName());
         assertEquals("Sample 메뉴", cartDto.getMenuName());

--- a/src/test/java/com/my/foody/domain/cart/service/CartServiceTest.java
+++ b/src/test/java/com/my/foody/domain/cart/service/CartServiceTest.java
@@ -76,7 +76,7 @@ public class CartServiceTest {
         Page<Cart> cartItemsPage = new PageImpl<>(Arrays.asList(cartItem));
 
         //userService의 findById 스텁 추가
-        when(userService.findByIdOrFail(userId)).thenReturn(user);
+        when(userService.findActivateUserByIdOrFail(userId)).thenReturn(user);
         when(cartRepository.findByUserId(userId, pageable)).thenReturn(cartItemsPage);
 
         // when

--- a/src/test/java/com/my/foody/domain/cart/service/CartServiceTest.java
+++ b/src/test/java/com/my/foody/domain/cart/service/CartServiceTest.java
@@ -10,6 +10,8 @@ import java.util.Arrays;
 
 import com.my.foody.domain.menu.entity.Menu;
 import com.my.foody.domain.store.entity.Store;
+import com.my.foody.domain.user.entity.User;
+import com.my.foody.domain.user.service.UserService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -28,14 +30,23 @@ public class CartServiceTest {
     @Mock
     private CartRepository cartRepository;
 
+    @Mock
+    private UserService userService;
+
     @InjectMocks
     private CartService cartService;
 
     private Cart cartItem;
+    private User user;
 
 
     @BeforeEach
     public void setUp() {
+
+        user = User.builder()
+                .id(1L)
+                .name("Test user")
+                .build();
 
         Store store = Store.builder()
                 .name("Test 음식점")
@@ -63,6 +74,9 @@ public class CartServiceTest {
         Pageable pageable = PageRequest.of(page, limit, Sort.by("id").descending());
 
         Page<Cart> cartItemsPage = new PageImpl<>(Arrays.asList(cartItem));
+
+        //userService의 findById 스텁 추가
+        when(userService.findByIdOrFail(userId)).thenReturn(user);
         when(cartRepository.findByUserId(userId, pageable)).thenReturn(cartItemsPage);
 
         // when


### PR DESCRIPTION
### 전체 시나리오

- Client가 주문하기 전에 메뉴를 선택하여 장바구니에 담는다
- 주문하기 전에 장바구니의 내용 조회 (가게이름, 선택한 메뉴 이름, 선택한 메뉴 가격, 선택한 메뉴 수량, 총 주문 금액, 최소 주문 금액, 페이징 정보)

### 장바구니 조회 단위 테스트
장바구니에 있는 것들이 잘 나오는지 확인