### PR TITLE
주문상태변경 기능 구현

### DIFF
--- a/src/main/java/com/my/foody/domain/order/controller/OrderController.java
+++ b/src/main/java/com/my/foody/domain/order/controller/OrderController.java
@@ -24,13 +24,12 @@ public class OrderController {
     public ResponseEntity<OrderStatusUpdateRespDto> changeOrderStatus(@PathVariable("orderId") Long orderId,
                                                                       @RequestBody OrderStatusUpdateReqDto requestDto,
                                                                       @CurrentUser TokenSubject tokenSubject) {
-        //ownerId
+        // ownerId
         Long ownerId = tokenSubject.getId();
 
-        // 주문 상태 업데이트
-        ResponseEntity<OrderStatusUpdateRespDto> responseEntity = orderService.updateOrderStatus(requestDto, orderId, tokenSubject.getId());
+        // 주문 상태 업데이트 및 응답 DTO 반환
+        OrderStatusUpdateRespDto responseDto = orderService.updateOrderStatus(requestDto, orderId, ownerId);
 
-        // ResponseEntity의 본문 반환
-        return responseEntity;
+        return ResponseEntity.ok(responseDto);
     }
 }

--- a/src/main/java/com/my/foody/domain/order/controller/OrderController.java
+++ b/src/main/java/com/my/foody/domain/order/controller/OrderController.java
@@ -1,4 +1,36 @@
 package com.my.foody.domain.order.controller;
 
+import com.my.foody.domain.order.dto.req.OrderStatusUpdateReqDto;
+import com.my.foody.domain.order.dto.resp.OrderStatusUpdateRespDto;
+import com.my.foody.domain.order.service.OrderService;
+import com.my.foody.global.config.valid.CurrentUser;
+import com.my.foody.global.config.valid.RequireAuth;
+import com.my.foody.global.jwt.TokenSubject;
+import com.my.foody.global.jwt.UserType;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
 public class OrderController {
+    private final OrderService orderService;
+
+    @PutMapping("api/owners/orders/{orderId}")
+    @RequireAuth(userType = UserType.OWNER)
+    public ResponseEntity<OrderStatusUpdateRespDto> changeOrderStatus(@PathVariable("orderId") Long orderId,
+                                                                      @RequestBody OrderStatusUpdateReqDto requestDto,
+                                                                      @CurrentUser TokenSubject tokenSubject) {
+        //ownerId
+        Long ownerId = tokenSubject.getId();
+
+        // 주문 상태 업데이트
+        ResponseEntity<OrderStatusUpdateRespDto> responseEntity = orderService.updateOrderStatus(requestDto, orderId, tokenSubject.getId());
+
+        // ResponseEntity의 본문 반환
+        return responseEntity;
+    }
 }

--- a/src/main/java/com/my/foody/domain/order/dto/req/OrderStatusUpdateReqDto.java
+++ b/src/main/java/com/my/foody/domain/order/dto/req/OrderStatusUpdateReqDto.java
@@ -1,10 +1,13 @@
 package com.my.foody.domain.order.dto.req;
 
-import jakarta.validation.constraints.NotBlank;
+import com.my.foody.domain.owner.entity.OrderStatus;
+import jakarta.validation.constraints.NotNull;
+import lombok.Builder;
 import lombok.Getter;
 
+@Builder
 @Getter
 public class OrderStatusUpdateReqDto {
-    @NotBlank(message = "주문상태를 입력해 주세요")
-    private String orderStatus;
+    @NotNull(message = "주문상태를 입력해 주세요")
+    private OrderStatus orderStatus;
 }

--- a/src/main/java/com/my/foody/domain/order/dto/req/OrderStatusUpdateReqDto.java
+++ b/src/main/java/com/my/foody/domain/order/dto/req/OrderStatusUpdateReqDto.java
@@ -1,0 +1,10 @@
+package com.my.foody.domain.order.dto.req;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+
+@Getter
+public class OrderStatusUpdateReqDto {
+    @NotBlank(message = "주문상태를 입력해 주세요")
+    private String orderStatus;
+}

--- a/src/main/java/com/my/foody/domain/order/dto/resp/OrderStatusUpdateRespDto.java
+++ b/src/main/java/com/my/foody/domain/order/dto/resp/OrderStatusUpdateRespDto.java
@@ -6,5 +6,5 @@ import lombok.Getter;
 @Getter
 @AllArgsConstructor
 public class OrderStatusUpdateRespDto {
-    private  String orderStaust;
+    private  String orderStatus;
 }

--- a/src/main/java/com/my/foody/domain/order/dto/resp/OrderStatusUpdateRespDto.java
+++ b/src/main/java/com/my/foody/domain/order/dto/resp/OrderStatusUpdateRespDto.java
@@ -1,0 +1,10 @@
+package com.my.foody.domain.order.dto.resp;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class OrderStatusUpdateRespDto {
+    private  String orderStaust;
+}

--- a/src/main/java/com/my/foody/domain/order/entity/Order.java
+++ b/src/main/java/com/my/foody/domain/order/entity/Order.java
@@ -37,5 +37,5 @@ public class Order extends BaseEntity {
 
     @Column(nullable = false)
     @Enumerated(EnumType.STRING)
-    private OrderStatus orderStatus;
+    private OrderStatus orderStatus = OrderStatus.PENDING; //기본값 설정
 }

--- a/src/main/java/com/my/foody/domain/order/entity/Order.java
+++ b/src/main/java/com/my/foody/domain/order/entity/Order.java
@@ -49,7 +49,7 @@ public class Order extends BaseEntity {
         this.totalAmount = totalAmount;
     }
 
-    public void updateOrderStatus(String status) {
-        this.orderStatus = OrderStatus.valueOf(status);
+    public void updateOrderStatus(OrderStatus orderStatus) {
+        this.orderStatus = orderStatus;
     }
 }

--- a/src/main/java/com/my/foody/domain/order/entity/Order.java
+++ b/src/main/java/com/my/foody/domain/order/entity/Order.java
@@ -7,6 +7,7 @@ import com.my.foody.domain.store.entity.Store;
 import com.my.foody.domain.user.entity.User;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -38,4 +39,17 @@ public class Order extends BaseEntity {
     @Column(nullable = false)
     @Enumerated(EnumType.STRING)
     private OrderStatus orderStatus = OrderStatus.PENDING; //기본값 설정
+
+    @Builder
+    public Order(OrderStatus orderStatus, User user, Store store, Address address, Long totalAmount) {
+        this.orderStatus = orderStatus;
+        this.user = user;
+        this.store = store;
+        this.address = address;
+        this.totalAmount = totalAmount;
+    }
+
+    public void updateOrderStatus(String status) {
+        this.orderStatus = OrderStatus.valueOf(status);
+    }
 }

--- a/src/main/java/com/my/foody/domain/order/service/OrderService.java
+++ b/src/main/java/com/my/foody/domain/order/service/OrderService.java
@@ -1,7 +1,42 @@
 package com.my.foody.domain.order.service;
 
+import com.my.foody.domain.order.dto.req.OrderStatusUpdateReqDto;
+import com.my.foody.domain.order.dto.resp.OrderStatusUpdateRespDto;
+import com.my.foody.domain.order.entity.Order;
+import com.my.foody.domain.order.repo.OrderRepository;
+import com.my.foody.domain.owner.entity.Owner;
+import com.my.foody.domain.owner.repo.OwnerRepository;
+import com.my.foody.domain.store.entity.Store;
+import com.my.foody.domain.store.repo.StoreRepository;
+import com.my.foody.global.ex.BusinessException;
+import com.my.foody.global.ex.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 
 @Service
+@RequiredArgsConstructor
 public class OrderService {
+    private final OrderRepository orderRepository;
+
+    public ResponseEntity<OrderStatusUpdateRespDto> updateOrderStatus(OrderStatusUpdateReqDto requestDto, Long orderId, Long ownerId) {
+        Order order = orderRepository.findById(orderId).orElseThrow(() -> new BusinessException(ErrorCode.ORDER_NOT_FOUND));
+        
+        // 가게 주인 맞는지 확인
+        if(!order.getStore().getId().equals(ownerId)) {
+            throw new BusinessException(ErrorCode.FORBIDDEN_ACCESS);
+        }
+
+        // 주문 상태 업데이트
+        order.updateOrderStatus(requestDto.getOrderStatus());
+
+        // 변경된 주문 저장
+        Order savedOrder = orderRepository.save(order);
+
+        // 응답 DTO 생성
+        OrderStatusUpdateRespDto responseDto = new OrderStatusUpdateRespDto(savedOrder.getOrderStatus().name());
+
+        // ResponseEntity로 반환
+        return ResponseEntity.ok(responseDto);
+    }
 }

--- a/src/main/java/com/my/foody/domain/order/service/OrderService.java
+++ b/src/main/java/com/my/foody/domain/order/service/OrderService.java
@@ -4,26 +4,24 @@ import com.my.foody.domain.order.dto.req.OrderStatusUpdateReqDto;
 import com.my.foody.domain.order.dto.resp.OrderStatusUpdateRespDto;
 import com.my.foody.domain.order.entity.Order;
 import com.my.foody.domain.order.repo.OrderRepository;
-import com.my.foody.domain.owner.entity.Owner;
-import com.my.foody.domain.owner.repo.OwnerRepository;
-import com.my.foody.domain.store.entity.Store;
-import com.my.foody.domain.store.repo.StoreRepository;
 import com.my.foody.global.ex.BusinessException;
 import com.my.foody.global.ex.ErrorCode;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
+
+@Transactional
 public class OrderService {
     private final OrderRepository orderRepository;
 
-    public ResponseEntity<OrderStatusUpdateRespDto> updateOrderStatus(OrderStatusUpdateReqDto requestDto, Long orderId, Long ownerId) {
+    public OrderStatusUpdateRespDto updateOrderStatus(OrderStatusUpdateReqDto requestDto, Long orderId, Long ownerId) {
         Order order = orderRepository.findById(orderId).orElseThrow(() -> new BusinessException(ErrorCode.ORDER_NOT_FOUND));
-        
+
         // 가게 주인 맞는지 확인
-        if(!order.getStore().getId().equals(ownerId)) {
+        if (!order.getStore().getOwner().getId().equals(ownerId)) {
             throw new BusinessException(ErrorCode.FORBIDDEN_ACCESS);
         }
 
@@ -34,9 +32,6 @@ public class OrderService {
         Order savedOrder = orderRepository.save(order);
 
         // 응답 DTO 생성
-        OrderStatusUpdateRespDto responseDto = new OrderStatusUpdateRespDto(savedOrder.getOrderStatus().name());
-
-        // ResponseEntity로 반환
-        return ResponseEntity.ok(responseDto);
+        return new OrderStatusUpdateRespDto(savedOrder.getOrderStatus().name());
     }
 }

--- a/src/main/java/com/my/foody/domain/owner/entity/OrderStatus.java
+++ b/src/main/java/com/my/foody/domain/owner/entity/OrderStatus.java
@@ -1,9 +1,19 @@
 package com.my.foody.domain.owner.entity;
 
 import lombok.Getter;
+import lombok.RequiredArgsConstructor;
 
 @Getter
 public enum OrderStatus {
+    PENDING("대기중"),
+    ACCEPTED("접수완료"),
+    CANCELLED("취소됨"),
+    DELIVERED("배달완료");
 
-    PENDING, ACCEPTED, CANCELLED, DELIVERED
+    private final String description;
+
+    OrderStatus(String description) {
+        this.description = description;
+    }
 }
+

--- a/src/main/java/com/my/foody/global/ex/ErrorCode.java
+++ b/src/main/java/com/my/foody/global/ex/ErrorCode.java
@@ -17,6 +17,11 @@ public enum ErrorCode {
     USER_NOT_FOUND(HttpStatus.NOT_FOUND.value(), "존재하지 않는 유저입니다"),
     INVALID_PASSWORD(HttpStatus.BAD_REQUEST.value(), "비밀번호가 일치하지 않습니다"),
     INVALID_TOKEN(HttpStatus.UNAUTHORIZED.value(), "유효하지 않은 인증 정보 입니다"),
+
+    ORDER_NOT_FOUND(HttpStatus.NOT_FOUND.value(), "존재하지 않는 주문입니다"),
+    STORE_NOT_FOUND(HttpStatus.NOT_FOUND.value(), "존재하지 않는 가게입니다"),
+
+
     ;
 
     private final int status;

--- a/src/main/java/com/my/foody/global/util/DummyObject.java
+++ b/src/main/java/com/my/foody/global/util/DummyObject.java
@@ -1,7 +1,13 @@
 package com.my.foody.global.util;
 
 import com.my.foody.domain.address.entity.Address;
+import com.my.foody.domain.order.entity.Order;
+import com.my.foody.domain.owner.entity.OrderStatus;
+import com.my.foody.domain.owner.entity.Owner;
+import com.my.foody.domain.store.entity.Store;
 import com.my.foody.domain.user.entity.User;
+
+import java.time.LocalTime;
 
 public class DummyObject {
 
@@ -16,7 +22,6 @@ public class DummyObject {
                 .build();
     }
 
-
     protected Address mockAddress(User user){
         return Address.builder()
                 .user(user)
@@ -24,4 +29,70 @@ public class DummyObject {
                 .detailedAddress("상세주소")
                 .build();
     }
+    
+    //사장
+    protected Owner mockOwner(Long id){
+        String password = "password123!";
+        return Owner.builder()
+                .id(id)
+                .email("ownertest@naver.com")
+                .password(PasswordEncoder.encode(password))
+                .contact("010-1234-5678")
+                .name("ownerA")
+                .build();
+    }
+
+
+    //id 가진 user
+    protected User newUser(Long id){
+        String password = "Maeda1234!";
+        return User.builder()
+                .id(id)
+                .email("user1234@naver.com")
+                .password(PasswordEncoder.encode(password))
+                .contact("010-1234-5678")
+                .name("userA")
+                .nickname("userrr")
+                .build();
+    }
+
+
+    //사장
+    protected Owner newOwner(Long id){
+        String password = "password123!";
+        return Owner.builder()
+                .id(id)
+                .email("ownertest@naver.com")
+                .password(PasswordEncoder.encode(password))
+                .contact("010-1234-5678")
+                .name("ownerA")
+                .build();
+    }
+
+    //가게
+    protected Store mockStore(Owner owner) {
+        return Store.builder()
+                .name("가게이름")
+                .owner(owner)
+                .description("가게설명")
+                .contact("010-1234-5678")
+                .minOrderAmount(10000L)
+                .openTime(LocalTime.of(9, 0))
+                .endTime(LocalTime.of(22, 0))
+                .isDeleted(false)
+                .build();
+    }
+
+    //주문
+    protected Order mockOrder(Owner owner, User user, Address address) {
+        Store store = mockStore(owner);
+        return Order.builder()
+                .orderStatus(OrderStatus.PENDING)
+                .user(user)
+                .store(store)
+                .address(address)
+                .totalAmount(10000L)
+                .build();
+    }
+
 }

--- a/src/test/java/com/my/foody/domain/order/service/OrderServiceTest.java
+++ b/src/test/java/com/my/foody/domain/order/service/OrderServiceTest.java
@@ -1,0 +1,113 @@
+package com.my.foody.domain.order.service;
+
+import com.my.foody.domain.address.entity.Address;
+import com.my.foody.domain.order.dto.req.OrderStatusUpdateReqDto;
+import com.my.foody.domain.order.dto.resp.OrderStatusUpdateRespDto;
+import com.my.foody.domain.order.entity.Order;
+import com.my.foody.domain.order.repo.OrderRepository;
+import com.my.foody.domain.owner.entity.OrderStatus;
+import com.my.foody.domain.owner.entity.Owner;
+import com.my.foody.domain.store.entity.Store;
+import com.my.foody.domain.user.entity.User;
+import com.my.foody.global.ex.BusinessException;
+import com.my.foody.global.ex.ErrorCode;
+import com.my.foody.global.util.DummyObject;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+public class OrderServiceTest extends DummyObject {
+
+    @InjectMocks
+    private OrderService orderService;
+
+    @Mock
+    private OrderRepository orderRepository;
+
+    private Order order;
+    private Owner owner;
+    private Store store;
+    private User user;
+    private Address address;
+
+    @BeforeEach
+    public void setUp() {
+        owner = mockOwner(1L);
+        store = mockStore(owner);
+        user = newUser(1L);
+        address = mockAddress(user);
+        order = mockOrder(owner, user, address);
+    }
+
+    @Test
+    @DisplayName("주문 상태 변경 성공 테스트")
+    void updateOrderStatus_Success() {
+
+        Long orderId = 1L;
+        Long ownerId = 1L;
+
+        // 빌더 사용
+        OrderStatusUpdateReqDto requestDto = OrderStatusUpdateReqDto.builder()
+                .orderStatus(OrderStatus.ACCEPTED)
+                .build();
+
+        // Mock 설정
+        when(orderRepository.findById(orderId)).thenReturn(Optional.of(order));
+        when(orderRepository.save(any(Order.class))).thenReturn(order);
+
+        OrderStatusUpdateRespDto responseDto = orderService.updateOrderStatus(requestDto, orderId, ownerId);
+
+        // 변경된 주문 상태 출력
+        System.out.println("변경된 주문 상태: " + responseDto.getOrderStatus());
+
+        assertAll(
+                () -> assertNotNull(responseDto),
+                () -> assertEquals(OrderStatus.ACCEPTED.name(), responseDto.getOrderStatus())
+        );
+
+        verify(orderRepository).findById(orderId);
+        verify(orderRepository).save(any(Order.class));
+    }
+
+
+    @Test
+    @DisplayName(value = "주문 상태 변경실패 테스트 권한없음")
+    void updateFailure() {
+        Long orderId = 1L;  // 테스트할 주문 ID
+        Long ownerId = 2L;  // 실제 주문의 가게 주인 ID와 다른 가게 주인 ID
+
+        OrderStatusUpdateReqDto requestDto = OrderStatusUpdateReqDto.builder()
+                .orderStatus(OrderStatus.ACCEPTED)
+                .build();
+
+        // Mock 설정: 주문이 존재하지만, 주인의 ID가 일치하지 않음
+        when(orderRepository.findById(orderId)).thenReturn(Optional.of(order));
+
+        try {
+            // 예외 발생 검증
+            orderService.updateOrderStatus(requestDto, orderId, ownerId);
+            System.out.println("테스트 실패: 예외가 발생하지 않았습니다."); // 예외가 발생하지 않을 경우 메시지 출력
+        } catch (BusinessException exception) {
+            // 예외 메시지 검증
+            assertEquals(ErrorCode.FORBIDDEN_ACCESS, exception.getErrorCode());
+
+            System.out.println("테스트 성공:" + exception.getErrorCode() + " 예외가 발생했습니다."); // 예외 발생 시 메시지 출력
+        }
+
+        // 주문 저장 메서드는 호출되지 않아야 함
+        verify(orderRepository, never()).save(any(Order.class));
+    }
+
+
+}


### PR DESCRIPTION
[주문상태변경 기능] 이슈 #5 
가게에 주문이 들어오면 주문 상태는 기본값인 "대기중" PENDING으로 설정
요청 본문에 "ACCEPTED"인 경우 주문 상태를 ACCEPTED로 변경
요청 본문에 "CANCELLED"인 경우 주문 상태를 CANCELLED로 변경
요청 본문에 "DELIVERED"인 경우 주문 상태를 DELIVERED로 변경

그래서 기존 엔티티 변경하고 enum 설명 추가, api 명세서상 post -> put으로 변경
Order Entity: OrderStatus의 기본값을 PENDING으로 설정
Enum OrderStatus: 각 상태에 대한 설명 추가

[테스트]
테스트 성공 케이스 : 해당 가게 주인이 본인 가게의 주문일 경우 주문상태 변경 가능
테스트 실패 케이스 : 해당 가게 주인이 아닐 경우 권한이 없으므로 주문상태 변경 불가능