### PR TITLE
유저 비밀번호 변경 기능

### DIFF
--- a/src/main/java/com/my/foody/domain/user/controller/UserController.java
+++ b/src/main/java/com/my/foody/domain/user/controller/UserController.java
@@ -5,11 +5,9 @@ import com.my.foody.domain.address.dto.req.AddressModifyReqDto;
 import com.my.foody.domain.address.dto.resp.AddressCreateRespDto;
 import com.my.foody.domain.address.dto.resp.AddressModifyRespDto;
 import com.my.foody.domain.user.dto.req.UserLoginReqDto;
+import com.my.foody.domain.user.dto.req.UserPasswordModifyReqDto;
 import com.my.foody.domain.user.dto.req.UserSignUpReqDto;
-import com.my.foody.domain.user.dto.resp.AddressDeleteRespDto;
-import com.my.foody.domain.user.dto.resp.UserInfoRespDto;
-import com.my.foody.domain.user.dto.resp.UserLoginRespDto;
-import com.my.foody.domain.user.dto.resp.UserSignUpRespDto;
+import com.my.foody.domain.user.dto.resp.*;
 import com.my.foody.domain.user.service.UserService;
 import com.my.foody.global.config.valid.CurrentUser;
 import com.my.foody.global.config.valid.RequireAuth;
@@ -70,6 +68,12 @@ public class UserController {
         return new ResponseEntity<>(ApiResult.success(userService.deleteAddressById(addressId, tokenSubject.getId())), HttpStatus.OK);
     }
 
+    @RequireAuth(userType = UserType.USER)
+    @PatchMapping("/mypage/pw")
+    public ResponseEntity<ApiResult<UserPasswordModifyRespDto>> modifyUserPassword(@RequestBody @Valid UserPasswordModifyReqDto userPasswordModifyReqDto,
+                                                                                   @CurrentUser TokenSubject tokenSubject){
+        return new ResponseEntity<>(ApiResult.success(userService.modifyUserPassword(userPasswordModifyReqDto, tokenSubject.getId())), HttpStatus.OK);
+    }
 
 
 }

--- a/src/main/java/com/my/foody/domain/user/dto/req/UserPasswordModifyReqDto.java
+++ b/src/main/java/com/my/foody/domain/user/dto/req/UserPasswordModifyReqDto.java
@@ -3,11 +3,15 @@ package com.my.foody.domain.user.dto.req;
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.my.foody.domain.user.dto.req.valid.ValidPassword;
 import jakarta.validation.constraints.AssertTrue;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @NoArgsConstructor
 @Getter
+@AllArgsConstructor
+@Builder
 public class UserPasswordModifyReqDto {
 
     @ValidPassword

--- a/src/main/java/com/my/foody/domain/user/dto/req/UserPasswordModifyReqDto.java
+++ b/src/main/java/com/my/foody/domain/user/dto/req/UserPasswordModifyReqDto.java
@@ -1,0 +1,27 @@
+package com.my.foody.domain.user.dto.req;
+
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.my.foody.domain.user.dto.req.valid.ValidPassword;
+import jakarta.validation.constraints.AssertTrue;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor
+@Getter
+public class UserPasswordModifyReqDto {
+
+    @ValidPassword
+    private String currentPassword;
+
+    @ValidPassword
+    private String newPassword;
+
+    @AssertTrue(message = "새로운 비밀번호는 현재 비밀번호와 달라야 합니다")
+    public boolean isPasswordDifferent(){
+        if(currentPassword != null || newPassword != null){
+            return true;
+        }
+        return !currentPassword.equals(newPassword);
+    }
+
+}

--- a/src/main/java/com/my/foody/domain/user/dto/req/UserPasswordModifyReqDto.java
+++ b/src/main/java/com/my/foody/domain/user/dto/req/UserPasswordModifyReqDto.java
@@ -22,7 +22,7 @@ public class UserPasswordModifyReqDto {
 
     @AssertTrue(message = "새로운 비밀번호는 현재 비밀번호와 달라야 합니다")
     public boolean isPasswordDifferent(){
-        if(currentPassword != null || newPassword != null){
+        if(currentPassword == null || newPassword == null){
             return true;
         }
         return !currentPassword.equals(newPassword);

--- a/src/main/java/com/my/foody/domain/user/dto/resp/UserPasswordModifyRespDto.java
+++ b/src/main/java/com/my/foody/domain/user/dto/resp/UserPasswordModifyRespDto.java
@@ -1,0 +1,14 @@
+package com.my.foody.domain.user.dto.resp;
+
+import lombok.Getter;
+
+@Getter
+public class UserPasswordModifyRespDto {
+
+    private static final String SUCCESS_MESSAGE = "변경 되었습니다";
+    private String message;
+
+    public UserPasswordModifyRespDto() {
+        this.message = SUCCESS_MESSAGE;
+    }
+}

--- a/src/main/java/com/my/foody/domain/user/entity/User.java
+++ b/src/main/java/com/my/foody/domain/user/entity/User.java
@@ -50,7 +50,7 @@ public class User extends BaseEntity {
 
     public void validPassword(String currentPassword) {
         if(!PasswordEncoder.matches(currentPassword, this.password)){
-            throw new BusinessException(ErrorCode.INVALID_PASSWORD)
+            throw new BusinessException(ErrorCode.INVALID_PASSWORD);
         }
     }
 

--- a/src/main/java/com/my/foody/domain/user/entity/User.java
+++ b/src/main/java/com/my/foody/domain/user/entity/User.java
@@ -47,4 +47,14 @@ public class User extends BaseEntity {
             throw new BusinessException(ErrorCode.INVALID_PASSWORD);
         }
     }
+
+    public void validPassword(String currentPassword) {
+        if(!PasswordEncoder.matches(currentPassword, this.password)){
+            throw new BusinessException(ErrorCode.INVALID_PASSWORD)
+        }
+    }
+
+    public void changePassword(String newPassword) {
+        this.password = PasswordEncoder.encode(newPassword);
+    }
 }

--- a/src/main/java/com/my/foody/domain/user/service/UserService.java
+++ b/src/main/java/com/my/foody/domain/user/service/UserService.java
@@ -9,11 +9,9 @@ import com.my.foody.domain.address.entity.Address;
 import com.my.foody.domain.address.repo.AddressRepository;
 import com.my.foody.domain.address.service.AddressService;
 import com.my.foody.domain.user.dto.req.UserLoginReqDto;
+import com.my.foody.domain.user.dto.req.UserPasswordModifyReqDto;
 import com.my.foody.domain.user.dto.req.UserSignUpReqDto;
-import com.my.foody.domain.user.dto.resp.AddressDeleteRespDto;
-import com.my.foody.domain.user.dto.resp.UserInfoRespDto;
-import com.my.foody.domain.user.dto.resp.UserLoginRespDto;
-import com.my.foody.domain.user.dto.resp.UserSignUpRespDto;
+import com.my.foody.domain.user.dto.resp.*;
 import com.my.foody.domain.user.entity.User;
 import com.my.foody.domain.user.repo.UserRepository;
 import com.my.foody.global.ex.BusinessException;
@@ -99,5 +97,13 @@ public class UserService {
         address.validateUser(user);
         addressRepository.delete(address);
         return new AddressDeleteRespDto();
+    }
+
+    @Transactional
+    public UserPasswordModifyRespDto modifyUserPassword(UserPasswordModifyReqDto userPasswordModifyReqDto, Long userId) {
+        User user = findByIdOrFail(userId);
+        user.validPassword(userPasswordModifyReqDto.getCurrentPassword());
+        user.changePassword(userPasswordModifyReqDto.getNewPassword());
+        return new UserPasswordModifyRespDto();
     }
 }

--- a/src/test/java/com/my/foody/domain/user/service/UserServiceTest.java
+++ b/src/test/java/com/my/foody/domain/user/service/UserServiceTest.java
@@ -8,11 +8,9 @@ import com.my.foody.domain.address.entity.Address;
 import com.my.foody.domain.address.repo.AddressRepository;
 import com.my.foody.domain.address.service.AddressService;
 import com.my.foody.domain.user.dto.req.UserLoginReqDto;
+import com.my.foody.domain.user.dto.req.UserPasswordModifyReqDto;
 import com.my.foody.domain.user.dto.req.UserSignUpReqDto;
-import com.my.foody.domain.user.dto.resp.AddressDeleteRespDto;
-import com.my.foody.domain.user.dto.resp.UserInfoRespDto;
-import com.my.foody.domain.user.dto.resp.UserLoginRespDto;
-import com.my.foody.domain.user.dto.resp.UserSignUpRespDto;
+import com.my.foody.domain.user.dto.resp.*;
 import com.my.foody.domain.user.entity.User;
 import com.my.foody.domain.user.repo.UserRepository;
 import com.my.foody.global.ex.BusinessException;
@@ -27,6 +25,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
 
 import java.util.Optional;
 
@@ -395,6 +394,66 @@ class UserServiceTest extends DummyObject {
         verify(addressService).findByIdOrFail(addressId);
         verify(addressRepository, never()).delete(any(Address.class));
     }
+
+    @Test
+    @DisplayName("비밀번호 변경 성공 테스트")
+    void modifyUserPassword_Success() {
+        Long userId = 1L;
+        String currentPassword = "Maeda1234!";
+        String newPassword = "BBnew123!";
+        User user = newUser(userId);
+
+        UserPasswordModifyReqDto reqDto = UserPasswordModifyReqDto.builder()
+                .currentPassword(currentPassword)
+                .newPassword(newPassword)
+                .build();
+
+        when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+
+        // when
+        UserPasswordModifyRespDto respDto = userService.modifyUserPassword(reqDto, userId);
+
+        // then
+        assertThat(PasswordEncoder.matches(newPassword, user.getPassword())).isTrue();
+        verify(userRepository, times(1)).findById(userId);
+    }
+
+    @Test
+    @DisplayName("비밀번호 변경 실패 테스트: 존재하지 않는 유저")
+    void modifyUserPassword_UserNotFound() {
+        Long userId = 999L;
+        UserPasswordModifyReqDto reqDto = new UserPasswordModifyReqDto();
+
+        when(userRepository.findById(userId)).thenReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> userService.modifyUserPassword(reqDto, userId))
+                .isInstanceOf(BusinessException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.USER_NOT_FOUND);
+    }
+
+    @Test
+    @DisplayName("비밀번호 변경 실패 테스트: 비밀번호 불일치")
+    void modifyUserPassword_InvalidCurrentPassword() {
+        // given
+        Long userId = 1L;
+        String wrongPassword = "wrong123!";
+        String newPassword = "new123!";
+        User user = newUser(userId);
+
+        UserPasswordModifyReqDto reqDto = UserPasswordModifyReqDto.builder()
+                .currentPassword(wrongPassword)
+                .newPassword(newPassword)
+                .build();
+
+        when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+
+        // when & then
+        assertThatThrownBy(() -> userService.modifyUserPassword(reqDto, userId))
+                .isInstanceOf(BusinessException.class)
+                .hasFieldOrPropertyWithValue("errorCode",ErrorCode.INVALID_PASSWORD);
+    }
+
 
     private UserSignUpReqDto mockUserSignUpReqDto(){
         return UserSignUpReqDto.builder()


### PR DESCRIPTION
## 전체 시나리오
1. 클라이언트의 비밀번호 변경 요청
2. 토큰 검증
3. DTO 유효성 검증 -> 변경 요청하는 비밀번호와 같다면 에러 throw
4. 해당 유저 조회 -> 존재하지 않을 시 에러 throw
5. 해당 유저의 비밀번호가 맞는지 검증 -> 불일치 시 에러 throw
6. 수정
7. 수정 완료 응답 반환

## 유저 비밀번호 수정 단위 테스트 추가
### **1. ✅ 비밀번호 수정 성공**
    - 정상적인 수정 케이스 검증

### **2. ❌ 비밀번호 수정 실패 케이스**
    - 존재하지 않는 사용자: USER_NOT_FOUND 검증
    - 비밀번호 불일치: INVALID_PASSWORD 검증
    