### PR TITLE
유저 탈퇴 기능 

### DIFF
--- a/src/main/java/com/my/foody/domain/cart/controller/CartController.java
+++ b/src/main/java/com/my/foody/domain/cart/controller/CartController.java
@@ -25,8 +25,8 @@ public class CartController {
     @RequireAuth(userType = UserType.USER) // User 인증 확인
     @GetMapping
     public ResponseEntity<ApiResult<Page<CartCreateRespDto>>> getCartItems(
-            @RequestParam int page,
-            @RequestParam int limit,
+            @RequestParam(value = "page") int page,
+            @RequestParam(value = "limit") int limit,
             @CurrentUser TokenSubject tokenSubject) {
 
         Long userId = tokenSubject.getId();

--- a/src/main/java/com/my/foody/domain/user/controller/UserController.java
+++ b/src/main/java/com/my/foody/domain/user/controller/UserController.java
@@ -82,7 +82,7 @@ public class UserController {
 
 
     @RequireAuth(userType = UserType.USER)
-    @DeleteMapping()
+    @DeleteMapping
     public ResponseEntity<ApiResult<UserDeleteRespDto>> deleteAddress(@RequestBody @Valid UserDeleteReqDto userDeleteReqDto,
                                                                       @CurrentUser TokenSubject tokenSubject){
         return new ResponseEntity<>(ApiResult.success(userService.deleteUserById(userDeleteReqDto, tokenSubject.getId())), HttpStatus.OK);

--- a/src/main/java/com/my/foody/domain/user/controller/UserController.java
+++ b/src/main/java/com/my/foody/domain/user/controller/UserController.java
@@ -3,6 +3,8 @@ package com.my.foody.domain.user.controller;
 import com.my.foody.domain.address.dto.req.AddressCreateReqDto;
 import com.my.foody.domain.address.dto.req.AddressModifyReqDto;
 import com.my.foody.domain.address.dto.resp.AddressCreateRespDto;
+import com.my.foody.domain.user.dto.req.UserDeleteReqDto;
+import com.my.foody.domain.user.dto.resp.UserDeleteRespDto;
 import com.my.foody.domain.user.dto.req.UserInfoModifyReqDto;
 import com.my.foody.domain.user.dto.req.UserLoginReqDto;
 import com.my.foody.domain.user.dto.req.UserSignUpReqDto;
@@ -76,6 +78,14 @@ public class UserController {
     public ResponseEntity<ApiResult<AddressDeleteRespDto>> deleteAddress(@PathVariable(value = "addressId") Long addressId,
                                                                          @CurrentUser TokenSubject tokenSubject){
         return new ResponseEntity<>(ApiResult.success(userService.deleteAddressById(addressId, tokenSubject.getId())), HttpStatus.OK);
+    }
+
+
+    @RequireAuth(userType = UserType.USER)
+    @DeleteMapping()
+    public ResponseEntity<ApiResult<UserDeleteRespDto>> deleteAddress(@RequestBody @Valid UserDeleteReqDto userDeleteReqDto,
+                                                                      @CurrentUser TokenSubject tokenSubject){
+        return new ResponseEntity<>(ApiResult.success(userService.deleteUserById(userDeleteReqDto, tokenSubject.getId())), HttpStatus.OK);
     }
 
 

--- a/src/main/java/com/my/foody/domain/user/dto/req/UserDeleteReqDto.java
+++ b/src/main/java/com/my/foody/domain/user/dto/req/UserDeleteReqDto.java
@@ -2,11 +2,13 @@ package com.my.foody.domain.user.dto.req;
 
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.my.foody.domain.user.dto.req.valid.ValidPassword;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @NoArgsConstructor
 @Getter
+@AllArgsConstructor
 public class UserDeleteReqDto {
 
     @ValidPassword

--- a/src/main/java/com/my/foody/domain/user/dto/req/UserDeleteReqDto.java
+++ b/src/main/java/com/my/foody/domain/user/dto/req/UserDeleteReqDto.java
@@ -1,0 +1,14 @@
+package com.my.foody.domain.user.dto.req;
+
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.my.foody.domain.user.dto.req.valid.ValidPassword;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor
+@Getter
+public class UserDeleteReqDto {
+
+    @ValidPassword
+    private String currentPassword;
+}

--- a/src/main/java/com/my/foody/domain/user/dto/resp/UserDeleteRespDto.java
+++ b/src/main/java/com/my/foody/domain/user/dto/resp/UserDeleteRespDto.java
@@ -1,0 +1,16 @@
+package com.my.foody.domain.user.dto.resp;
+
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+public class UserDeleteRespDto {
+
+    private static final String SUCCESS_MESSAGE = "삭제 완료 되었습니다";
+    private final String message;
+
+    public UserDeleteRespDto() {
+        this.message = SUCCESS_MESSAGE;
+    }
+}

--- a/src/main/java/com/my/foody/domain/user/entity/User.java
+++ b/src/main/java/com/my/foody/domain/user/entity/User.java
@@ -59,4 +59,14 @@ public class User extends BaseEntity {
     private String updateIfValid(String newValue, String currentValue) {
         return StringUtils.hasText(newValue) ? newValue.trim() : currentValue;
     }
+
+    public void validPassword(String currentPassword) {
+        if(!PasswordEncoder.matches(currentPassword, this.password)){
+            throw new BusinessException(ErrorCode.INVALID_PASSWORD);
+        }
+    }
+
+    public void deactivate(){
+        this.isDeleted = true;
+    }
 }

--- a/src/main/java/com/my/foody/domain/user/repo/UserRepository.java
+++ b/src/main/java/com/my/foody/domain/user/repo/UserRepository.java
@@ -3,6 +3,7 @@ package com.my.foody.domain.user.repo;
 import com.my.foody.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.Optional;
@@ -17,5 +18,5 @@ public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> findByEmail(String email);
 
     @Query("select u from User u where u.id = :userId and u.isDeleted = false")
-    Optional<User> findActivateUser(Long userId);
+    Optional<User> findActivateUser(@Param(value = "userId")Long userId);
 }

--- a/src/main/java/com/my/foody/domain/user/repo/UserRepository.java
+++ b/src/main/java/com/my/foody/domain/user/repo/UserRepository.java
@@ -2,6 +2,7 @@ package com.my.foody.domain.user.repo;
 
 import com.my.foody.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 import java.util.Optional;
@@ -14,4 +15,7 @@ public interface UserRepository extends JpaRepository<User, Long> {
     boolean existsByNickname(String nickname);
 
     Optional<User> findByEmail(String email);
+
+    @Query("select u from User u where u.id = :userId and u.isDeleted = false")
+    Optional<User> findActivateUser(Long userId);
 }

--- a/src/main/java/com/my/foody/domain/user/service/UserService.java
+++ b/src/main/java/com/my/foody/domain/user/service/UserService.java
@@ -119,9 +119,6 @@ public class UserService {
     @Transactional
     public UserDeleteRespDto deleteUserById(UserDeleteReqDto userDeleteReqDto, Long userId) {
         User user = findActivateUserByIdOrFail(userId);
-        if (user.getIsDeleted()) {
-            throw new BusinessException(ErrorCode.ALREADY_DEACTIVATED_USER);
-        }
         user.validPassword(userDeleteReqDto.getCurrentPassword());
         user.deactivate();
         return new UserDeleteRespDto();

--- a/src/main/java/com/my/foody/domain/user/service/UserService.java
+++ b/src/main/java/com/my/foody/domain/user/service/UserService.java
@@ -124,5 +124,6 @@ public class UserService {
         }
         user.validPassword(userDeleteReqDto.getCurrentPassword());
         user.deactivate();
+        return new UserDeleteRespDto();
     }
 }

--- a/src/main/java/com/my/foody/domain/user/service/UserService.java
+++ b/src/main/java/com/my/foody/domain/user/service/UserService.java
@@ -51,6 +51,9 @@ public class UserService {
     public UserLoginRespDto login(UserLoginReqDto userLoginReqDto){
         User user = userRepository.findByEmail(userLoginReqDto.getEmail())
                 .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
+        if(user.getIsDeleted()){
+            throw new BusinessException(ErrorCode.ALREADY_DEACTIVATED_USER);
+        }
         user.matchPassword(userLoginReqDto.getPassword());
         String token = jwtProvider.create(TokenSubject.of(user));
         return new UserLoginRespDto(token);

--- a/src/main/java/com/my/foody/global/ex/ErrorCode.java
+++ b/src/main/java/com/my/foody/global/ex/ErrorCode.java
@@ -19,7 +19,8 @@ public enum ErrorCode {
     INVALID_TOKEN(HttpStatus.UNAUTHORIZED.value(), "유효하지 않은 인증 정보 입니다"),
     ADDRESS_NOT_FOUND(HttpStatus.NOT_FOUND.value(), "존재하지 않는 주소지입니다"),
     UNAUTHORIZED_ADDRESS_ACCESS(HttpStatus.UNAUTHORIZED.value(), "해당 주소지에 접근 권한이 없습니다"),
-    INVALID_ADDRESS_FORMAT(HttpStatus.BAD_REQUEST.value(), "유효하지 않은 주소 형식입니다");
+    INVALID_ADDRESS_FORMAT(HttpStatus.BAD_REQUEST.value(), "유효하지 않은 주소 형식입니다"),
+    ALREADY_DEACTIVATED_USER(HttpStatus.BAD_REQUEST.value(), "이미 탈퇴한 유저입니다");
 
     private final int status;
     private final String msg;

--- a/src/main/java/com/my/foody/global/ex/ErrorCode.java
+++ b/src/main/java/com/my/foody/global/ex/ErrorCode.java
@@ -20,7 +20,7 @@ public enum ErrorCode {
     ADDRESS_NOT_FOUND(HttpStatus.NOT_FOUND.value(), "존재하지 않는 주소지입니다"),
     UNAUTHORIZED_ADDRESS_ACCESS(HttpStatus.UNAUTHORIZED.value(), "해당 주소지에 접근 권한이 없습니다"),
     INVALID_ADDRESS_FORMAT(HttpStatus.BAD_REQUEST.value(), "유효하지 않은 주소 형식입니다"),
-    ALREADY_DEACTIVATED_USER(HttpStatus.BAD_REQUEST.value(), "이미 탈퇴한 유저입니다");
+    ALREADY_DEACTIVATED_USER(HttpStatus.BAD_REQUEST.value(), "탈퇴한 유저입니다");
 
     private final int status;
     private final String msg;

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -1,3 +1,3 @@
 spring:
   profiles:
-    active: test
+    active: demo


### PR DESCRIPTION
## 전체 시나리오
1. 회원 탈퇴 요청
2. 토큰 검증
3. 유저 조회 -> 존재하지 않을 시 에러 throw
4. 유저의 현재 비밀번호와 일치하는지 검증 -> 불일치 시 에러 throw
5. 유저의 isDeleted = true 설정
6. 탈퇴 완료 응답 반환

## 회원 탈퇴 단위 테스트 추가
### **1. ✅ 회원 탈퇴 성공**
    - 정상적인 수정 케이스 검증

### **2. ❌ 회원 탈퇴 실패 케이스**
    - 존재하지 않는 사용자: USER_NOT_FOUND 검증
    - 비밀번호 불일치: INVALID_PASSWORD 검증
    - 이미 탈퇴한 회원: ALREADY_DEACTIVATED_USER
    