### PR TITLE
주문 완료 전 페이지 기능

### DIFF
--- a/src/main/java/com/my/foody/FoodyApplication.java
+++ b/src/main/java/com/my/foody/FoodyApplication.java
@@ -5,9 +5,7 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 
 @SpringBootApplication
 public class FoodyApplication {
-
     public static void main(String[] args) {
         SpringApplication.run(FoodyApplication.class, args);
     }
-
 }

--- a/src/main/java/com/my/foody/domain/address/entity/Address.java
+++ b/src/main/java/com/my/foody/domain/address/entity/Address.java
@@ -29,7 +29,7 @@ public class Address extends BaseEntity {
     @Column(length = 30, nullable = false)
     private String detailedAddress;
 
-    Boolean isMain;
+    private Boolean isMain;
 
     @Builder
     public Address(Long id, User user, String roadAddress, String detailedAddress) {

--- a/src/main/java/com/my/foody/domain/address/entity/Address.java
+++ b/src/main/java/com/my/foody/domain/address/entity/Address.java
@@ -29,6 +29,8 @@ public class Address extends BaseEntity {
     @Column(length = 30, nullable = false)
     private String detailedAddress;
 
+    Boolean isMain;
+
     @Builder
     public Address(Long id, User user, String roadAddress, String detailedAddress) {
         this.id = id;

--- a/src/main/java/com/my/foody/domain/address/repo/AddressRepository.java
+++ b/src/main/java/com/my/foody/domain/address/repo/AddressRepository.java
@@ -9,6 +9,6 @@ import org.springframework.stereotype.Repository;
 
 @Repository
 public interface AddressRepository extends JpaRepository<Address, Long> {
-    Optional<Address> findByUserId(Long userId);
     List<Address> findAllByUserOrderByCreatedAtDesc(User user);
+    Optional<Address> findByUserIdAndIsMain(Long userId, Boolean isMain);
 }

--- a/src/main/java/com/my/foody/domain/address/repo/AddressRepository.java
+++ b/src/main/java/com/my/foody/domain/address/repo/AddressRepository.java
@@ -1,9 +1,11 @@
 package com.my.foody.domain.address.repo;
 
 import com.my.foody.domain.address.entity.Address;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface AddressRepository extends JpaRepository<Address, Long> {
+    Optional<Address> findByUserId(Long userId);
 }

--- a/src/main/java/com/my/foody/domain/address/repo/AddressRepository.java
+++ b/src/main/java/com/my/foody/domain/address/repo/AddressRepository.java
@@ -1,11 +1,16 @@
 package com.my.foody.domain.address.repo;
 
 import com.my.foody.domain.address.entity.Address;
+
+import java.util.List;
 import java.util.Optional;
+
+import com.my.foody.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface AddressRepository extends JpaRepository<Address, Long> {
     Optional<Address> findByUserId(Long userId);
+    List<Address> findAllByUserOrderByCreatedAtDesc(User user);
 }

--- a/src/main/java/com/my/foody/domain/address/service/AddressService.java
+++ b/src/main/java/com/my/foody/domain/address/service/AddressService.java
@@ -2,6 +2,7 @@ package com.my.foody.domain.address.service;
 
 import com.my.foody.domain.address.entity.Address;
 import com.my.foody.domain.address.repo.AddressRepository;
+import com.my.foody.domain.user.entity.User;
 import com.my.foody.global.ex.BusinessException;
 import com.my.foody.global.ex.ErrorCode;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/com/my/foody/domain/cart/repo/CartRepository.java
+++ b/src/main/java/com/my/foody/domain/cart/repo/CartRepository.java
@@ -6,7 +6,11 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
+
 @Repository
 public interface CartRepository extends JpaRepository<Cart, Long> {
     Page<Cart> findByUserId(Long userId, Pageable pageable);
+    Optional<Cart> findByIdAndUserIdAndStoreId(Long id, Long userId, Long storeId);
+
 }

--- a/src/main/java/com/my/foody/domain/cart/repo/CartRepository.java
+++ b/src/main/java/com/my/foody/domain/cart/repo/CartRepository.java
@@ -4,13 +4,17 @@ import com.my.foody.domain.cart.entity.Cart;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.Optional;
 
 @Repository
 public interface CartRepository extends JpaRepository<Cart, Long> {
-    Page<Cart> findByUserId(Long userId, Pageable pageable);
-    Optional<Cart> findByIdAndUserIdAndStoreId(Long id, Long userId, Long storeId);
-
+  Page<Cart> findByUserId(Long userId, Pageable pageable);
+  @Query(
+      "SELECT c FROM Cart c JOIN FETCH c.store s JOIN FETCH c.menu m WHERE c.id = :cartId AND c.user.id = :userId AND s.id = :storeId")
+  Optional<Cart> findWithStoreAndMenuByIdAndUserIdAndStoreId(
+      @Param("cartId") Long cartId, @Param("userId") Long userId, @Param("storeId") Long storeId);
 }

--- a/src/main/java/com/my/foody/domain/cart/service/CartService.java
+++ b/src/main/java/com/my/foody/domain/cart/service/CartService.java
@@ -11,6 +11,9 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 
+import java.util.List;
+import java.util.stream.Collectors;
+
 @Service
 @RequiredArgsConstructor
 public class CartService {

--- a/src/main/java/com/my/foody/domain/cart/service/CartService.java
+++ b/src/main/java/com/my/foody/domain/cart/service/CartService.java
@@ -11,9 +11,6 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 
-import java.util.List;
-import java.util.stream.Collectors;
-
 @Service
 @RequiredArgsConstructor
 public class CartService {
@@ -23,8 +20,8 @@ public class CartService {
 
     public Page<CartItemRespDto> getCartItems(Long userId, int page, int limit) {
 
-        //User의 존재 검증
-        userService.findByIdOrFail(userId);
+        //Active User의 존재 검증
+        userService.findActivateUserByIdOrFail(userId);
 
         Pageable pageable = PageRequest.of(page, limit, Sort.by("id").descending());
         Page<Cart> cartItemsPage = cartRepository.findByUserId(userId, pageable);

--- a/src/main/java/com/my/foody/domain/category/repo/CategoryRepository.java
+++ b/src/main/java/com/my/foody/domain/category/repo/CategoryRepository.java
@@ -6,4 +6,5 @@ import org.springframework.stereotype.Repository;
 
 @Repository
 public interface CategoryRepository extends JpaRepository<Category, Long> {
+
 }

--- a/src/main/java/com/my/foody/domain/order/controller/OrderController.java
+++ b/src/main/java/com/my/foody/domain/order/controller/OrderController.java
@@ -4,7 +4,6 @@ import com.my.foody.domain.order.dto.req.OrderStatusUpdateReqDto;
 import com.my.foody.domain.order.dto.resp.OrderPreviewRespDto;
 import com.my.foody.domain.order.dto.resp.OrderStatusUpdateRespDto;
 import com.my.foody.domain.order.service.OrderService;
-import com.my.foody.domain.user.service.UserService;
 import com.my.foody.global.config.valid.CurrentUser;
 import com.my.foody.global.config.valid.RequireAuth;
 import com.my.foody.global.jwt.TokenSubject;
@@ -20,7 +19,6 @@ import org.springframework.web.bind.annotation.*;
 public class OrderController {
 
   private final OrderService orderService;
-  private final UserService userService;
 
   @PutMapping("api/owners/orders/{orderId}")
   @RequireAuth(userType = UserType.OWNER)

--- a/src/main/java/com/my/foody/domain/order/controller/OrderController.java
+++ b/src/main/java/com/my/foody/domain/order/controller/OrderController.java
@@ -1,8 +1,10 @@
 package com.my.foody.domain.order.controller;
 
 import com.my.foody.domain.order.dto.req.OrderStatusUpdateReqDto;
+import com.my.foody.domain.order.dto.resp.OrderPreviewRespDto;
 import com.my.foody.domain.order.dto.resp.OrderStatusUpdateRespDto;
 import com.my.foody.domain.order.service.OrderService;
+import com.my.foody.domain.user.service.UserService;
 import com.my.foody.global.config.valid.CurrentUser;
 import com.my.foody.global.config.valid.RequireAuth;
 import com.my.foody.global.jwt.TokenSubject;
@@ -11,28 +13,42 @@ import com.my.foody.global.util.api.ApiResult;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PutMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
 public class OrderController {
-    private final OrderService orderService;
 
-    @PutMapping("api/owners/orders/{orderId}")
-    @RequireAuth(userType = UserType.OWNER)
-    public ResponseEntity<ApiResult<OrderStatusUpdateRespDto>> changeOrderStatus(@PathVariable("orderId") Long orderId,
-                                                                                 @RequestBody OrderStatusUpdateReqDto requestDto,
-                                                                                 @CurrentUser TokenSubject tokenSubject) {
-        // ownerId
-        Long ownerId = tokenSubject.getId();
+  private final OrderService orderService;
+  private final UserService userService;
 
-        // 주문 상태 업데이트 및 응답 DTO 반환
-        OrderStatusUpdateRespDto responseDto = orderService.updateOrderStatus(requestDto, orderId, ownerId);
-        ApiResult<OrderStatusUpdateRespDto> apiResult = ApiResult.success(responseDto);
+  @PutMapping("api/owners/orders/{orderId}")
+  @RequireAuth(userType = UserType.OWNER)
+  public ResponseEntity<ApiResult<OrderStatusUpdateRespDto>> changeOrderStatus(
+      @PathVariable("orderId") Long orderId,
+      @RequestBody OrderStatusUpdateReqDto requestDto,
+      @CurrentUser TokenSubject tokenSubject) {
 
-        return new ResponseEntity<>(apiResult, HttpStatus.OK);
-    }
+    Long ownerId = tokenSubject.getId();
+
+    // 주문 상태 업데이트 및 응답 DTO 반환
+    OrderStatusUpdateRespDto responseDto = orderService.updateOrderStatus(requestDto, orderId, ownerId);
+    ApiResult<OrderStatusUpdateRespDto> apiResult = ApiResult.success(responseDto);
+
+    return new ResponseEntity<>(apiResult, HttpStatus.OK);
+  }
+
+  @GetMapping("/api/home/stores/{storeId}/cart/{cartId}/orders")
+  @RequireAuth(userType = UserType.USER)
+  public ResponseEntity<ApiResult<OrderPreviewRespDto>> getOrderPreview(
+          @PathVariable Long storeId,
+          @PathVariable Long cartId,
+          @CurrentUser TokenSubject tokenSubject) {
+
+    Long userId = tokenSubject.getId();
+    OrderPreviewRespDto orderPreview = orderService.getOrderPreview(userId, storeId, cartId);
+    ApiResult<OrderPreviewRespDto> apiResult = ApiResult.success(orderPreview);
+
+    return new ResponseEntity<>(apiResult, HttpStatus.OK);
+  }
 }

--- a/src/main/java/com/my/foody/domain/order/controller/OrderController.java
+++ b/src/main/java/com/my/foody/domain/order/controller/OrderController.java
@@ -1,4 +1,38 @@
 package com.my.foody.domain.order.controller;
 
+import com.my.foody.domain.order.dto.req.OrderStatusUpdateReqDto;
+import com.my.foody.domain.order.dto.resp.OrderStatusUpdateRespDto;
+import com.my.foody.domain.order.service.OrderService;
+import com.my.foody.global.config.valid.CurrentUser;
+import com.my.foody.global.config.valid.RequireAuth;
+import com.my.foody.global.jwt.TokenSubject;
+import com.my.foody.global.jwt.UserType;
+import com.my.foody.global.util.api.ApiResult;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
 public class OrderController {
+    private final OrderService orderService;
+
+    @PutMapping("api/owners/orders/{orderId}")
+    @RequireAuth(userType = UserType.OWNER)
+    public ResponseEntity<ApiResult<OrderStatusUpdateRespDto>> changeOrderStatus(@PathVariable("orderId") Long orderId,
+                                                                                 @RequestBody OrderStatusUpdateReqDto requestDto,
+                                                                                 @CurrentUser TokenSubject tokenSubject) {
+        // ownerId
+        Long ownerId = tokenSubject.getId();
+
+        // 주문 상태 업데이트 및 응답 DTO 반환
+        OrderStatusUpdateRespDto responseDto = orderService.updateOrderStatus(requestDto, orderId, ownerId);
+        ApiResult<OrderStatusUpdateRespDto> apiResult = ApiResult.success(responseDto);
+
+        return new ResponseEntity<>(apiResult, HttpStatus.OK);
+    }
 }

--- a/src/main/java/com/my/foody/domain/order/dto/req/OrderStatusUpdateReqDto.java
+++ b/src/main/java/com/my/foody/domain/order/dto/req/OrderStatusUpdateReqDto.java
@@ -1,0 +1,13 @@
+package com.my.foody.domain.order.dto.req;
+
+import com.my.foody.domain.owner.entity.OrderStatus;
+import jakarta.validation.constraints.NotNull;
+import lombok.Builder;
+import lombok.Getter;
+
+@Builder
+@Getter
+public class OrderStatusUpdateReqDto {
+    @NotNull(message = "주문상태를 입력해 주세요")
+    private OrderStatus orderStatus;
+}

--- a/src/main/java/com/my/foody/domain/order/dto/resp/OrderPreviewRespDto.java
+++ b/src/main/java/com/my/foody/domain/order/dto/resp/OrderPreviewRespDto.java
@@ -1,0 +1,20 @@
+package com.my.foody.domain.order.dto.resp;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class OrderPreviewRespDto {
+    private String roadAddress;
+    private String detailedAddress;
+    private String userContact;
+    private String storeName;
+    private Long storeId;
+    private String menuName;
+    private Long menuPrice;
+    private Long quantity;
+    private Long totalAmount;
+}

--- a/src/main/java/com/my/foody/domain/order/dto/resp/OrderStatusUpdateRespDto.java
+++ b/src/main/java/com/my/foody/domain/order/dto/resp/OrderStatusUpdateRespDto.java
@@ -1,0 +1,10 @@
+package com.my.foody.domain.order.dto.resp;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class OrderStatusUpdateRespDto {
+    private  String orderStatus;
+}

--- a/src/main/java/com/my/foody/domain/order/entity/Order.java
+++ b/src/main/java/com/my/foody/domain/order/entity/Order.java
@@ -5,8 +5,11 @@ import com.my.foody.domain.base.BaseEntity;
 import com.my.foody.domain.owner.entity.OrderStatus;
 import com.my.foody.domain.store.entity.Store;
 import com.my.foody.domain.user.entity.User;
+import com.my.foody.global.ex.BusinessException;
+import com.my.foody.global.ex.ErrorCode;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -37,5 +40,24 @@ public class Order extends BaseEntity {
 
     @Column(nullable = false)
     @Enumerated(EnumType.STRING)
-    private OrderStatus orderStatus;
+    private OrderStatus orderStatus = OrderStatus.PENDING; //기본값 설정
+
+    @Builder
+    public Order(OrderStatus orderStatus, User user, Store store, Address address, Long totalAmount) {
+        this.orderStatus = orderStatus;
+        this.user = user;
+        this.store = store;
+        this.address = address;
+        this.totalAmount = totalAmount;
+    }
+
+    public void updateOrderStatus(OrderStatus orderStatus) {
+        this.orderStatus = orderStatus;
+    }
+
+    public void isStoreOwner(Long ownerId) {
+        if (!this.store.getOwner().getId().equals(ownerId)) {
+            throw new BusinessException(ErrorCode.FORBIDDEN_ACCESS);
+        }
+    }
 }

--- a/src/main/java/com/my/foody/domain/order/service/OrderService.java
+++ b/src/main/java/com/my/foody/domain/order/service/OrderService.java
@@ -1,9 +1,19 @@
 package com.my.foody.domain.order.service;
 
+import com.my.foody.domain.address.entity.Address;
+import com.my.foody.domain.address.repo.AddressRepository;
+import com.my.foody.domain.cart.entity.Cart;
+import com.my.foody.domain.cart.repo.CartRepository;
+import com.my.foody.domain.menu.entity.Menu;
 import com.my.foody.domain.order.dto.req.OrderStatusUpdateReqDto;
+import com.my.foody.domain.order.dto.resp.OrderPreviewRespDto;
 import com.my.foody.domain.order.dto.resp.OrderStatusUpdateRespDto;
 import com.my.foody.domain.order.entity.Order;
 import com.my.foody.domain.order.repo.OrderRepository;
+import com.my.foody.domain.store.entity.Store;
+import com.my.foody.domain.store.repo.StoreRepository;
+import com.my.foody.domain.user.entity.User;
+import com.my.foody.domain.user.repo.UserRepository;
 import com.my.foody.global.ex.BusinessException;
 import com.my.foody.global.ex.ErrorCode;
 import lombok.RequiredArgsConstructor;
@@ -15,6 +25,11 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional
 public class OrderService {
     private final OrderRepository orderRepository;
+    private UserRepository userRepository;
+    private final CartRepository cartRepository;
+    private final StoreRepository storeRepository;
+    private final AddressRepository addressRepository;
+
 
     public OrderStatusUpdateRespDto updateOrderStatus(OrderStatusUpdateReqDto requestDto, Long orderId, Long ownerId) {
         Order order = orderRepository.findById(orderId).orElseThrow(() -> new BusinessException(ErrorCode.ORDER_NOT_FOUND));
@@ -30,5 +45,34 @@ public class OrderService {
 
         // 응답 DTO 생성
         return new OrderStatusUpdateRespDto(savedOrder.getOrderStatus().name());
+    }
+
+    public OrderPreviewRespDto getOrderPreview(Long userId, Long storeId, Long cartId) {
+        // Fetch the user
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
+
+        Address address = addressRepository.findByUserId(userId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.ADDRESS_NOT_FOUND));
+
+        Cart cart = cartRepository.findByIdAndUserIdAndStoreId(cartId, userId, storeId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.CART_ITEM_NOT_FOUND));
+
+        Store store = cart.getStore();
+        Menu menu = cart.getMenu();
+
+        Long totalAmount = menu.getPrice() * cart.getQuantity();
+
+        return OrderPreviewRespDto.builder()
+                .roadAddress(address.getRoadAddress())
+                .detailedAddress(address.getDetailedAddress())
+                .userContact(user.getContact())
+                .storeName(store.getName())
+                .storeId(store.getId())
+                .menuName(menu.getName())
+                .menuPrice(menu.getPrice())
+                .quantity(cart.getQuantity())
+                .totalAmount(totalAmount)
+                .build();
     }
 }

--- a/src/main/java/com/my/foody/domain/order/service/OrderService.java
+++ b/src/main/java/com/my/foody/domain/order/service/OrderService.java
@@ -11,7 +11,6 @@ import com.my.foody.domain.order.dto.resp.OrderStatusUpdateRespDto;
 import com.my.foody.domain.order.entity.Order;
 import com.my.foody.domain.order.repo.OrderRepository;
 import com.my.foody.domain.store.entity.Store;
-import com.my.foody.domain.store.repo.StoreRepository;
 import com.my.foody.domain.user.entity.User;
 import com.my.foody.domain.user.repo.UserRepository;
 import com.my.foody.global.ex.BusinessException;
@@ -25,9 +24,8 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional
 public class OrderService {
     private final OrderRepository orderRepository;
-    private UserRepository userRepository;
+    private final UserRepository userRepository;
     private final CartRepository cartRepository;
-    private final StoreRepository storeRepository;
     private final AddressRepository addressRepository;
 
 

--- a/src/main/java/com/my/foody/domain/order/service/OrderService.java
+++ b/src/main/java/com/my/foody/domain/order/service/OrderService.java
@@ -50,10 +50,10 @@ public class OrderService {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
 
-        Address address = addressRepository.findByUserId(userId)
+        Address address = addressRepository.findByUserIdAndIsMain(userId, true)
                 .orElseThrow(() -> new BusinessException(ErrorCode.ADDRESS_NOT_FOUND));
 
-        Cart cart = cartRepository.findByIdAndUserIdAndStoreId(cartId, userId, storeId)
+        Cart cart = cartRepository.findWithStoreAndMenuByIdAndUserIdAndStoreId(cartId, userId, storeId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.CART_ITEM_NOT_FOUND));
 
         Store store = cart.getStore();

--- a/src/main/java/com/my/foody/domain/order/service/OrderService.java
+++ b/src/main/java/com/my/foody/domain/order/service/OrderService.java
@@ -1,7 +1,34 @@
 package com.my.foody.domain.order.service;
 
+import com.my.foody.domain.order.dto.req.OrderStatusUpdateReqDto;
+import com.my.foody.domain.order.dto.resp.OrderStatusUpdateRespDto;
+import com.my.foody.domain.order.entity.Order;
+import com.my.foody.domain.order.repo.OrderRepository;
+import com.my.foody.global.ex.BusinessException;
+import com.my.foody.global.ex.ErrorCode;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
+@RequiredArgsConstructor
+@Transactional
 public class OrderService {
+    private final OrderRepository orderRepository;
+
+    public OrderStatusUpdateRespDto updateOrderStatus(OrderStatusUpdateReqDto requestDto, Long orderId, Long ownerId) {
+        Order order = orderRepository.findById(orderId).orElseThrow(() -> new BusinessException(ErrorCode.ORDER_NOT_FOUND));
+
+        // 가게 주인 맞는지 확인
+        order.isStoreOwner(ownerId);
+
+        // 주문 상태 업데이트
+        order.updateOrderStatus(requestDto.getOrderStatus());
+
+        // 변경된 주문 저장
+        Order savedOrder = orderRepository.save(order);
+
+        // 응답 DTO 생성
+        return new OrderStatusUpdateRespDto(savedOrder.getOrderStatus().name());
+    }
 }

--- a/src/main/java/com/my/foody/domain/user/service/UserService.java
+++ b/src/main/java/com/my/foody/domain/user/service/UserService.java
@@ -100,4 +100,9 @@ public class UserService {
         addressRepository.delete(address);
         return new AddressDeleteRespDto();
     }
+
+    public Long getUserIdFromToken(String token) {
+        TokenSubject tokenSubject = jwtProvider.validate(token);
+        return tokenSubject.getId();
+    }
 }

--- a/src/main/java/com/my/foody/domain/user/service/UserService.java
+++ b/src/main/java/com/my/foody/domain/user/service/UserService.java
@@ -100,9 +100,4 @@ public class UserService {
         addressRepository.delete(address);
         return new AddressDeleteRespDto();
     }
-
-    public Long getUserIdFromToken(String token) {
-        TokenSubject tokenSubject = jwtProvider.validate(token);
-        return tokenSubject.getId();
-    }
 }

--- a/src/main/java/com/my/foody/global/ex/ErrorCode.java
+++ b/src/main/java/com/my/foody/global/ex/ErrorCode.java
@@ -22,6 +22,7 @@ public enum ErrorCode {
     INVALID_ADDRESS_FORMAT(HttpStatus.BAD_REQUEST.value(), "유효하지 않은 주소 형식입니다"),
 
     ORDER_NOT_FOUND(HttpStatus.NOT_FOUND.value(), "존재하지 않는 주문입니다"),
+    CART_ITEM_NOT_FOUND(HttpStatus.NOT_FOUND.value(), "존재하지 않는 장바구니입니다.")
 
     ;
 

--- a/src/main/java/com/my/foody/global/ex/ErrorCode.java
+++ b/src/main/java/com/my/foody/global/ex/ErrorCode.java
@@ -19,7 +19,13 @@ public enum ErrorCode {
     INVALID_TOKEN(HttpStatus.UNAUTHORIZED.value(), "유효하지 않은 인증 정보 입니다"),
     ADDRESS_NOT_FOUND(HttpStatus.NOT_FOUND.value(), "존재하지 않는 주소지입니다"),
     UNAUTHORIZED_ADDRESS_ACCESS(HttpStatus.UNAUTHORIZED.value(), "해당 주소지에 접근 권한이 없습니다"),
-    INVALID_ADDRESS_FORMAT(HttpStatus.BAD_REQUEST.value(), "유효하지 않은 주소 형식입니다");
+    INVALID_ADDRESS_FORMAT(HttpStatus.BAD_REQUEST.value(), "유효하지 않은 주소 형식입니다"),
+
+    ORDER_NOT_FOUND(HttpStatus.NOT_FOUND.value(), "존재하지 않는 주문입니다"),
+
+    ;
+
+
 
     private final int status;
     private final String msg;

--- a/src/test/java/com/my/foody/domain/cart/service/CartServiceTest.java
+++ b/src/test/java/com/my/foody/domain/cart/service/CartServiceTest.java
@@ -76,7 +76,7 @@ public class CartServiceTest {
         Page<Cart> cartItemsPage = new PageImpl<>(Arrays.asList(cartItem));
 
         //userService의 findById 스텁 추가
-        when(userService.findByIdOrFail(userId)).thenReturn(user);
+        when(userService.findActivateUserByIdOrFail(userId)).thenReturn(user);
         when(cartRepository.findByUserId(userId, pageable)).thenReturn(cartItemsPage);
 
         // when

--- a/src/test/java/com/my/foody/domain/order/service/OrderServiceTest.java
+++ b/src/test/java/com/my/foody/domain/order/service/OrderServiceTest.java
@@ -148,8 +148,8 @@ public class OrderServiceTest extends DummyObject {
 
         //when
         when(userRepository.findById(userId)).thenReturn(Optional.of(user));
-        when(addressRepository.findByUserId(userId)).thenReturn(Optional.of(address));
-        when(cartRepository.findByIdAndUserIdAndStoreId(cartId, userId, storeId))
+        when(addressRepository.findByUserIdAndIsMain(userId,true)).thenReturn(Optional.of(address));
+        when(cartRepository.findWithStoreAndMenuByIdAndUserIdAndStoreId(cartId, userId, storeId))
                 .thenReturn(Optional.of(cart));
 
         //then
@@ -168,8 +168,8 @@ public class OrderServiceTest extends DummyObject {
 
         // Verifying the interactions with the mocks
         verify(userRepository).findById(userId);
-        verify(addressRepository).findByUserId(userId);
-        verify(cartRepository).findByIdAndUserIdAndStoreId(cartId, userId, storeId);
+        verify(addressRepository).findByUserIdAndIsMain(userId, true);
+        verify(cartRepository).findWithStoreAndMenuByIdAndUserIdAndStoreId(cartId, userId, storeId);
     }
 
     @Test
@@ -197,17 +197,15 @@ public class OrderServiceTest extends DummyObject {
         Long storeId = store.getId();
         Long cartId = cart.getId();
 
-        // Mocking behavior for dependencies
         when(userRepository.findById(userId)).thenReturn(Optional.of(user));
-        when(addressRepository.findByUserId(userId)).thenReturn(Optional.empty());
+        when(addressRepository.findByUserIdAndIsMain(userId, true)).thenReturn(Optional.empty());
 
-        // Exception verification
         assertThrows(BusinessException.class, () -> {
             orderService.getOrderPreview(userId, storeId, cartId);
         }, "예상된 ADDRESS_NOT_FOUND의 예외 처리");
 
         verify(userRepository).findById(userId);
-        verify(addressRepository).findByUserId(userId);
+        verify(addressRepository).findByUserIdAndIsMain(userId, true);
     }
 
     @Test
@@ -221,8 +219,8 @@ public class OrderServiceTest extends DummyObject {
 
         // when
         when(userRepository.findById(userId)).thenReturn(Optional.of(user));
-        when(addressRepository.findByUserId(userId)).thenReturn(Optional.of(address));
-        when(cartRepository.findByIdAndUserIdAndStoreId(cartId, userId, storeId))
+        when(addressRepository.findByUserIdAndIsMain(userId, true)).thenReturn(Optional.of(address));
+        when(cartRepository.findWithStoreAndMenuByIdAndUserIdAndStoreId(cartId, userId, storeId))
                 .thenReturn(Optional.empty());
 
        //then
@@ -231,7 +229,7 @@ public class OrderServiceTest extends DummyObject {
         }, "예상된 CART_ITEM_NOT_FOUND의 예외 처리");
 
         verify(userRepository).findById(userId);
-        verify(addressRepository).findByUserId(userId);
-        verify(cartRepository).findByIdAndUserIdAndStoreId(cartId, userId, storeId);
+        verify(addressRepository).findByUserIdAndIsMain(userId, true);
+        verify(cartRepository).findWithStoreAndMenuByIdAndUserIdAndStoreId(cartId, userId, storeId);
     }
 }


### PR DESCRIPTION
### 시나리오
- Client가 장바구니에 원하는 메뉴들을 선택한 후
- 주문을 완료하기 전에 client가 다음과 같은 종보를 확인할 수 있습니다: 
  * 도로명 주소
  * 상세 주소
  * user 연락처
  *가게 이름
  *가게 아이디  
  * 선택한 메뉴 이름
  * 선택한 메뉴 가격
  * 선택한 메뉴 수량
  * 결제 금액
  
###   주문 완료 전 페이지 단위 test
  - 주문 미리보기 성공 테스트
  - 주문 미리보기 실패 테스트 - 사용자 미발견
  - 주문 미리보기 실패 테스트 - 주소 미발견
  - 주문 미리보기 실패 테스트 - 카트 항목 미발견