### PR TITLE
장바구니 메뉴 담기 기능

### DIFF
--- a/src/main/java/com/my/foody/domain/cart/controller/CartController.java
+++ b/src/main/java/com/my/foody/domain/cart/controller/CartController.java
@@ -26,18 +26,18 @@ public class CartController {
 
 
     //TODO  이거 수정해야함!!!!
-    @RequireAuth(userType = UserType.USER) // User 인증 확인
-    @GetMapping("/cart")
-    public ResponseEntity<ApiResult<Page<CartItemRespDto>>> getCartItems(
-            @RequestParam int page,
-            @RequestParam int limit,
-            @CurrentUser TokenSubject tokenSubject) {
-
-        Long userId = tokenSubject.getId();
-        Page<CartItemRespDto> cartItems = cartService.getCartItems(userId, page, limit);
-
-        return ResponseEntity.ok(ApiResult.success(cartItems));
-    }
+//    @RequireAuth(userType = UserType.USER) // User 인증 확인
+//    @GetMapping("/cart")
+//    public ResponseEntity<ApiResult<Page<CartItemRespDto>>> getCartItems(
+//            @RequestParam int page,
+//            @RequestParam int limit,
+//            @CurrentUser TokenSubject tokenSubject) {
+//
+//        Long userId = tokenSubject.getId();
+//        Page<CartItemRespDto> cartItems = cartService.getCartItems(userId, page, limit);
+//
+//        return ResponseEntity.ok(ApiResult.success(cartItems));
+//    }
 
     @RequireAuth(userType = UserType.USER)
     @PostMapping("/home/stores/{storeId}/menus/{menuId}")

--- a/src/main/java/com/my/foody/domain/cart/controller/CartController.java
+++ b/src/main/java/com/my/foody/domain/cart/controller/CartController.java
@@ -1,29 +1,33 @@
 package com.my.foody.domain.cart.controller;
 
+import com.my.foody.domain.cart.dto.req.CartMenuCreateReqDto;
 import com.my.foody.domain.cart.dto.resp.CartItemRespDto;
+import com.my.foody.domain.cart.dto.resp.CartMenuCreateRespDto;
 import com.my.foody.domain.cart.service.CartService;
 import com.my.foody.global.config.valid.CurrentUser;
 import com.my.foody.global.config.valid.RequireAuth;
 import com.my.foody.global.jwt.TokenSubject;
 import com.my.foody.global.jwt.UserType;
 import com.my.foody.global.util.api.ApiResult;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.client.HttpServerErrorException;
 
 @RestController
-@RequestMapping("/api/cart")
+@RequestMapping("/api")
 @RequiredArgsConstructor
 public class CartController {
 
     private final CartService cartService;
 
+
+    //TODO  이거 수정해야함!!!!
     @RequireAuth(userType = UserType.USER) // User 인증 확인
-    @GetMapping
+    @GetMapping("/cart")
     public ResponseEntity<ApiResult<Page<CartItemRespDto>>> getCartItems(
             @RequestParam int page,
             @RequestParam int limit,
@@ -35,4 +39,12 @@ public class CartController {
         return ResponseEntity.ok(ApiResult.success(cartItems));
     }
 
+    @RequireAuth(userType = UserType.USER)
+    @PostMapping("/home/stores/{storeId}/menus/{menuId}")
+    public ResponseEntity<ApiResult<CartMenuCreateRespDto>> addCartItem(@PathVariable(value = "storeId")Long storeId,
+                                                                        @PathVariable(value = "menuId")Long menuId,
+                                                                        @RequestBody @Valid CartMenuCreateReqDto cartMenuCreateReqDto,
+                                                                        @CurrentUser TokenSubject tokenSubject){
+        return new ResponseEntity<>(ApiResult.success(cartService.addCartItem(storeId, menuId, cartMenuCreateReqDto, tokenSubject.getId())), HttpStatus.CREATED);
+    }
 }

--- a/src/main/java/com/my/foody/domain/cart/dto/req/CartMenuCreateReqDto.java
+++ b/src/main/java/com/my/foody/domain/cart/dto/req/CartMenuCreateReqDto.java
@@ -1,0 +1,16 @@
+package com.my.foody.domain.cart.dto.req;
+
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor
+@Getter
+public class CartMenuCreateReqDto {
+
+    @NotNull(message = "수량을 입력해주세요")
+    @Min(value = 1, message = "수량은 1개 이상이어야 합니다")
+    private Long quantity;
+}

--- a/src/main/java/com/my/foody/domain/cart/dto/req/CartMenuCreateReqDto.java
+++ b/src/main/java/com/my/foody/domain/cart/dto/req/CartMenuCreateReqDto.java
@@ -3,11 +3,13 @@ package com.my.foody.domain.cart.dto.req;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @NoArgsConstructor
 @Getter
+@AllArgsConstructor
 public class CartMenuCreateReqDto {
 
     @NotNull(message = "수량을 입력해주세요")

--- a/src/main/java/com/my/foody/domain/cart/dto/resp/CartMenuCreateRespDto.java
+++ b/src/main/java/com/my/foody/domain/cart/dto/resp/CartMenuCreateRespDto.java
@@ -2,6 +2,7 @@ package com.my.foody.domain.cart.dto.resp;
 
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.my.foody.domain.cartMenu.CartMenu;
+import com.my.foody.domain.cartMenu.CartMenuRepository;
 import com.my.foody.domain.menu.entity.Menu;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -12,18 +13,12 @@ import java.util.List;
 @Getter
 public class CartMenuCreateRespDto {
     private Long cartId;
+    private Long menuId;
+    private Long quantity;
 
-    private List<CartMenuRespDto> cartMenuList;
-
-    @NoArgsConstructor
-    @Getter
-    public static class CartMenuRespDto{
-        public CartMenuRespDto(CartMenu cartMenu) {
-            this.menuId = cartMenu.getMenu().getId();
-            this.quantity = cartMenu.getQuantity();
-        }
-
-        private Long menuId;
-        private Long quantity;
+    public CartMenuCreateRespDto(CartMenu cartMenu) {
+        this.cartId = cartMenu.getCart().getId();
+        this.menuId = cartMenu.getMenu().getId();
+        this.quantity = cartMenu.getQuantity();
     }
 }

--- a/src/main/java/com/my/foody/domain/cart/dto/resp/CartMenuCreateRespDto.java
+++ b/src/main/java/com/my/foody/domain/cart/dto/resp/CartMenuCreateRespDto.java
@@ -1,0 +1,29 @@
+package com.my.foody.domain.cart.dto.resp;
+
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.my.foody.domain.cartMenu.CartMenu;
+import com.my.foody.domain.menu.entity.Menu;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@NoArgsConstructor
+@Getter
+public class CartMenuCreateRespDto {
+    private Long cartId;
+
+    private List<CartMenuRespDto> cartMenuList;
+
+    @NoArgsConstructor
+    @Getter
+    public static class CartMenuRespDto{
+        public CartMenuRespDto(CartMenu cartMenu) {
+            this.menuId = cartMenu.getMenu().getId();
+            this.quantity = cartMenu.getQuantity();
+        }
+
+        private Long menuId;
+        private Long quantity;
+    }
+}

--- a/src/main/java/com/my/foody/domain/cart/entity/Cart.java
+++ b/src/main/java/com/my/foody/domain/cart/entity/Cart.java
@@ -18,16 +18,11 @@ public class Cart extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @ManyToOne(fetch = FetchType.LAZY)
+    @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id")
     private User user;
 
-    @ManyToOne(fetch = FetchType.LAZY)
+    @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "store_id")
     private Store store;
-
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "menu_id")
-    private Menu menu;
-    private Long quantity;
 }

--- a/src/main/java/com/my/foody/domain/cart/repo/CartRepository.java
+++ b/src/main/java/com/my/foody/domain/cart/repo/CartRepository.java
@@ -1,6 +1,7 @@
 package com.my.foody.domain.cart.repo;
 
 import com.my.foody.domain.cart.entity.Cart;
+import com.my.foody.domain.user.entity.User;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -17,4 +18,6 @@ public interface CartRepository extends JpaRepository<Cart, Long> {
       "SELECT c FROM Cart c JOIN FETCH c.store s JOIN FETCH c.menu m WHERE c.id = :cartId AND c.user.id = :userId AND s.id = :storeId")
   Optional<Cart> findWithStoreAndMenuByIdAndUserIdAndStoreId(
       @Param("cartId") Long cartId, @Param("userId") Long userId, @Param("storeId") Long storeId);
+
+  Optional<Cart> findByUser(User user);
 }

--- a/src/main/java/com/my/foody/domain/cart/service/CartService.java
+++ b/src/main/java/com/my/foody/domain/cart/service/CartService.java
@@ -1,7 +1,6 @@
 package com.my.foody.domain.cart.service;
 
 import com.my.foody.domain.cart.dto.req.CartMenuCreateReqDto;
-import com.my.foody.domain.cart.dto.resp.CartItemRespDto;
 import com.my.foody.domain.cart.dto.resp.CartMenuCreateRespDto;
 import com.my.foody.domain.cart.entity.Cart;
 import com.my.foody.domain.cart.repo.CartRepository;
@@ -14,14 +13,8 @@ import com.my.foody.domain.store.service.StoreService;
 import com.my.foody.domain.user.entity.User;
 import com.my.foody.domain.user.service.UserService;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageRequest;
-import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
@@ -63,7 +56,7 @@ public class CartService {
     public CartMenuCreateRespDto addCartItem(Long storeId, Long menuId, CartMenuCreateReqDto cartMenuCreateReqDto, Long userId) {
         User user = userService.findActivateUserByIdOrFail(userId);
         Store store = storeService.findActivateStoreByIdOrFail(storeId);
-        Menu menu = menuService.findByIdOrFail(menuId);
+        Menu menu = menuService.findActiveMenuByIdOrFail(menuId);
         Cart cart = cartRepository.findByUser(user)
                 .orElseGet(() -> {
                     return cartRepository.save(Cart.builder().store(store).user(user).build());

--- a/src/main/java/com/my/foody/domain/cart/service/CartService.java
+++ b/src/main/java/com/my/foody/domain/cart/service/CartService.java
@@ -5,6 +5,10 @@ import com.my.foody.domain.cart.dto.resp.CartItemRespDto;
 import com.my.foody.domain.cart.dto.resp.CartMenuCreateRespDto;
 import com.my.foody.domain.cart.entity.Cart;
 import com.my.foody.domain.cart.repo.CartRepository;
+import com.my.foody.domain.cartMenu.CartMenu;
+import com.my.foody.domain.cartMenu.CartMenuRepository;
+import com.my.foody.domain.menu.entity.Menu;
+import com.my.foody.domain.menu.service.MenuService;
 import com.my.foody.domain.store.entity.Store;
 import com.my.foody.domain.store.service.StoreService;
 import com.my.foody.domain.user.entity.User;
@@ -17,6 +21,8 @@ import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.Optional;
+
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
@@ -25,35 +31,50 @@ public class CartService {
     private final CartRepository cartRepository;
     private final UserService userService;
     private final StoreService storeService;
+    private final MenuService menuService;
+    private final CartMenuRepository cartMenuRepository;
 
-    public Page<CartItemRespDto> getCartItems(Long userId, int page, int limit) {
+    //TODO 수정해야 함
 
-        //Active User의 존재 검증
-        userService.findActivateUserByIdOrFail(userId);
+//    public Page<CartItemRespDto> getCartItems(Long userId, int page, int limit) {
+//
+//        //Active User의 존재 검증
+//        userService.findActivateUserByIdOrFail(userId);
+//
+//        Pageable pageable = PageRequest.of(page, limit, Sort.by("id").descending());
+//        Page<Cart> cartItemsPage = cartRepository.findByUserId(userId, pageable);
+//
+//    return cartItemsPage.map(
+//        cartItem -> {
+//          Long totalOrderAmount = cartItem.getMenu().getPrice() * cartItem.getQuantity();
+//          Long minOrderAmount = cartItem.getStore().getMinOrderAmount();
+//
+//          return new CartItemRespDto(
+//              cartItem.getStore().getName(),
+//              cartItem.getMenu().getName(),
+//              cartItem.getMenu().getPrice(),
+//              cartItem.getQuantity(),
+//              totalOrderAmount,
+//              minOrderAmount);
+//        });
+//    }
 
-        Pageable pageable = PageRequest.of(page, limit, Sort.by("id").descending());
-        Page<Cart> cartItemsPage = cartRepository.findByUserId(userId, pageable);
-
-    return cartItemsPage.map(
-        cartItem -> {
-          Long totalOrderAmount = cartItem.getMenu().getPrice() * cartItem.getQuantity();
-          Long minOrderAmount = cartItem.getStore().getMinOrderAmount();
-
-          return new CartItemRespDto(
-              cartItem.getStore().getName(),
-              cartItem.getMenu().getName(),
-              cartItem.getMenu().getPrice(),
-              cartItem.getQuantity(),
-              totalOrderAmount,
-              minOrderAmount);
-        });
-    }
-
+    @Transactional
     public CartMenuCreateRespDto addCartItem(Long storeId, Long menuId, CartMenuCreateReqDto cartMenuCreateReqDto, Long userId) {
         User user = userService.findActivateUserByIdOrFail(userId);
         Store store = storeService.findActivateStoreByIdOrFail(storeId);
+        Menu menu = menuService.findByIdOrFail(menuId);
+        Cart cart = cartRepository.findByUser(user)
+                .orElseGet(() -> {
+                    return cartRepository.save(Cart.builder().store(store).user(user).build());
+                });
+        CartMenu cartMenu = CartMenu.builder()
+                .cart(cart)
+                .menu(menu)
+                .quantity(cartMenuCreateReqDto.getQuantity()).build();
 
-
-
+        cartMenuRepository.save(cartMenu);
+        return new CartMenuCreateRespDto(cartMenu);
     }
+
 }

--- a/src/main/java/com/my/foody/domain/cart/service/CartService.java
+++ b/src/main/java/com/my/foody/domain/cart/service/CartService.java
@@ -1,8 +1,13 @@
 package com.my.foody.domain.cart.service;
 
+import com.my.foody.domain.cart.dto.req.CartMenuCreateReqDto;
 import com.my.foody.domain.cart.dto.resp.CartItemRespDto;
+import com.my.foody.domain.cart.dto.resp.CartMenuCreateRespDto;
 import com.my.foody.domain.cart.entity.Cart;
 import com.my.foody.domain.cart.repo.CartRepository;
+import com.my.foody.domain.store.entity.Store;
+import com.my.foody.domain.store.service.StoreService;
+import com.my.foody.domain.user.entity.User;
 import com.my.foody.domain.user.service.UserService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -10,13 +15,16 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class CartService {
 
     private final CartRepository cartRepository;
     private final UserService userService;
+    private final StoreService storeService;
 
     public Page<CartItemRespDto> getCartItems(Long userId, int page, int limit) {
 
@@ -39,5 +47,13 @@ public class CartService {
               totalOrderAmount,
               minOrderAmount);
         });
+    }
+
+    public CartMenuCreateRespDto addCartItem(Long storeId, Long menuId, CartMenuCreateReqDto cartMenuCreateReqDto, Long userId) {
+        User user = userService.findActivateUserByIdOrFail(userId);
+        Store store = storeService.findActivateStoreByIdOrFail(storeId);
+
+
+
     }
 }

--- a/src/main/java/com/my/foody/domain/cartMenu/CartMenu.java
+++ b/src/main/java/com/my/foody/domain/cartMenu/CartMenu.java
@@ -5,6 +5,7 @@ import com.my.foody.domain.cart.entity.Cart;
 import com.my.foody.domain.menu.entity.Menu;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -26,4 +27,12 @@ public class CartMenu extends BaseEntity {
     private Menu menu;
 
     private Long quantity;
+
+    @Builder
+    public CartMenu(Long id, Cart cart, Menu menu, Long quantity) {
+        this.id = id;
+        this.cart = cart;
+        this.menu = menu;
+        this.quantity = quantity;
+    }
 }

--- a/src/main/java/com/my/foody/domain/cartMenu/CartMenu.java
+++ b/src/main/java/com/my/foody/domain/cartMenu/CartMenu.java
@@ -1,0 +1,29 @@
+package com.my.foody.domain.cartMenu;
+
+import com.my.foody.domain.base.BaseEntity;
+import com.my.foody.domain.cart.entity.Cart;
+import com.my.foody.domain.menu.entity.Menu;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class CartMenu extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "cart_id")
+    private Cart cart;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "menu_id")
+    private Menu menu;
+
+    private Long quantity;
+}

--- a/src/main/java/com/my/foody/domain/cartMenu/CartMenuRepository.java
+++ b/src/main/java/com/my/foody/domain/cartMenu/CartMenuRepository.java
@@ -1,0 +1,8 @@
+package com.my.foody.domain.cartMenu;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface CartMenuRepository extends JpaRepository<CartMenu, Long> {
+}

--- a/src/main/java/com/my/foody/domain/menu/repo/MenuRepository.java
+++ b/src/main/java/com/my/foody/domain/menu/repo/MenuRepository.java
@@ -2,8 +2,14 @@ package com.my.foody.domain.menu.repo;
 
 import com.my.foody.domain.menu.entity.Menu;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
 
 @Repository
 public interface MenuRepository extends JpaRepository<Menu, Long> {
+
+    @Query("select m from Menu m where m.id = :menuId and m.isDeleted = false")
+    Optional<Menu> findActivateMenu(Long menuId);
 }

--- a/src/main/java/com/my/foody/domain/menu/service/MenuService.java
+++ b/src/main/java/com/my/foody/domain/menu/service/MenuService.java
@@ -1,4 +1,23 @@
 package com.my.foody.domain.menu.service;
 
+import com.my.foody.domain.menu.entity.Menu;
+import com.my.foody.domain.menu.repo.MenuRepository;
+import com.my.foody.domain.store.entity.Store;
+import com.my.foody.global.ex.BusinessException;
+import com.my.foody.global.ex.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class MenuService {
+
+    private final MenuRepository menuRepository;
+
+    public Menu findByIdOrFail(Long menuId){
+        return menuRepository.findById(menuId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.MENU_NOT_FOUND));
+    }
 }

--- a/src/main/java/com/my/foody/domain/menu/service/MenuService.java
+++ b/src/main/java/com/my/foody/domain/menu/service/MenuService.java
@@ -2,7 +2,6 @@ package com.my.foody.domain.menu.service;
 
 import com.my.foody.domain.menu.entity.Menu;
 import com.my.foody.domain.menu.repo.MenuRepository;
-import com.my.foody.domain.store.entity.Store;
 import com.my.foody.global.ex.BusinessException;
 import com.my.foody.global.ex.ErrorCode;
 import lombok.RequiredArgsConstructor;
@@ -16,8 +15,12 @@ public class MenuService {
 
     private final MenuRepository menuRepository;
 
-    public Menu findByIdOrFail(Long menuId){
-        return menuRepository.findById(menuId)
+    public Menu findActiveMenuByIdOrFail(Long menuId){
+        Menu menu = menuRepository.findActivateMenu(menuId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.MENU_NOT_FOUND));
+        if(menu.getIsSoldOut()){
+            throw new BusinessException(ErrorCode.MENU_NOT_AVAILABLE);
+        }
+        return menu;
     }
 }

--- a/src/main/java/com/my/foody/domain/order/service/OrderService.java
+++ b/src/main/java/com/my/foody/domain/order/service/OrderService.java
@@ -45,6 +45,7 @@ public class OrderService {
         return new OrderStatusUpdateRespDto(savedOrder.getOrderStatus().name());
     }
 
+    //TODO 이거 수정해야 함!!
     public OrderPreviewRespDto getOrderPreview(Long userId, Long storeId, Long cartId) {
         // Fetch the user
         User user = userRepository.findById(userId)
@@ -55,22 +56,23 @@ public class OrderService {
 
         Cart cart = cartRepository.findWithStoreAndMenuByIdAndUserIdAndStoreId(cartId, userId, storeId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.CART_ITEM_NOT_FOUND));
+        return null;
 
-        Store store = cart.getStore();
-        Menu menu = cart.getMenu();
-
-        Long totalAmount = menu.getPrice() * cart.getQuantity();
-
-        return OrderPreviewRespDto.builder()
-                .roadAddress(address.getRoadAddress())
-                .detailedAddress(address.getDetailedAddress())
-                .userContact(user.getContact())
-                .storeName(store.getName())
-                .storeId(store.getId())
-                .menuName(menu.getName())
-                .menuPrice(menu.getPrice())
-                .quantity(cart.getQuantity())
-                .totalAmount(totalAmount)
-                .build();
+//        Store store = cart.getStore();
+//        Menu menu = cart.getMenu();
+//
+//        Long totalAmount = menu.getPrice() * cart.getQuantity();
+//
+//        return OrderPreviewRespDto.builder()
+//                .roadAddress(address.getRoadAddress())
+//                .detailedAddress(address.getDetailedAddress())
+//                .userContact(user.getContact())
+//                .storeName(store.getName())
+//                .storeId(store.getId())
+//                .menuName(menu.getName())
+//                .menuPrice(menu.getPrice())
+//                .quantity(cart.getQuantity())
+//                .totalAmount(totalAmount)
+//                .build();
     }
 }

--- a/src/main/java/com/my/foody/domain/store/repo/StoreRepository.java
+++ b/src/main/java/com/my/foody/domain/store/repo/StoreRepository.java
@@ -1,10 +1,14 @@
 package com.my.foody.domain.store.repo;
 
 import com.my.foody.domain.store.entity.Store;
+import com.my.foody.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface StoreRepository extends JpaRepository<Store, Long> {
@@ -15,4 +19,7 @@ public interface StoreRepository extends JpaRepository<Store, Long> {
     List<Store> findByOwnerId(Long ownerId);
 
     Long countByOwnerIdAndIsDeletedFalse(Long ownerId);
+
+    @Query("select s from Store s where s.id = :storeId and s.isDeleted = false")
+    Optional<Store> findActivateStore(@Param(value = "storeId")Long storeId);
 }

--- a/src/main/java/com/my/foody/domain/store/service/StoreService.java
+++ b/src/main/java/com/my/foody/domain/store/service/StoreService.java
@@ -81,4 +81,9 @@ public class StoreService {
             throw new BusinessException(ErrorCode.HAVE_FULL_STORE);
         }
     }
+
+    public Store findActivateStoreByIdOrFail(Long storeId){
+        return storeRepository.findActivateStore(storeId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.STORE_NOT_FOUND));
+    }
 }

--- a/src/main/java/com/my/foody/global/ex/ErrorCode.java
+++ b/src/main/java/com/my/foody/global/ex/ErrorCode.java
@@ -33,7 +33,7 @@ public enum ErrorCode {
     OWNER_NOT_FOUND(HttpStatus.NOT_FOUND.value(), "OWNER를 찾을 수 없습니다."),
     CATEGORY_NOT_FOUND(HttpStatus.NOT_FOUND.value(), "존재하지 않는 카테고리입니다."),
     MENU_NOT_FOUND(HttpStatus.BAD_REQUEST.value(), "존재하지 않는 메뉴입니다"),
-    ;
+    MENU_NOT_AVAILABLE(HttpStatus.BAD_REQUEST.value(), "현재 주문할 수 없는 메뉴입니다");
 
 
     private final int status;

--- a/src/main/java/com/my/foody/global/ex/ErrorCode.java
+++ b/src/main/java/com/my/foody/global/ex/ErrorCode.java
@@ -32,6 +32,7 @@ public enum ErrorCode {
     HAVE_FULL_STORE(HttpStatus.CONFLICT.value(), "생성 가능한 가게 수를 초과합니다."),
     OWNER_NOT_FOUND(HttpStatus.NOT_FOUND.value(), "OWNER를 찾을 수 없습니다."),
     CATEGORY_NOT_FOUND(HttpStatus.NOT_FOUND.value(), "존재하지 않는 카테고리입니다."),
+    MENU_NOT_FOUND(HttpStatus.BAD_REQUEST.value(), "존재하지 않는 메뉴입니다"),
     ;
 
 

--- a/src/test/java/com/my/foody/domain/cart/controller/CartControllerTest.java
+++ b/src/test/java/com/my/foody/domain/cart/controller/CartControllerTest.java
@@ -1,0 +1,114 @@
+package com.my.foody.domain.cart.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.my.foody.domain.cart.dto.req.CartMenuCreateReqDto;
+import com.my.foody.domain.cart.dto.resp.CartMenuCreateRespDto;
+import com.my.foody.domain.cart.entity.Cart;
+import com.my.foody.domain.cart.service.CartService;
+import com.my.foody.domain.cartMenu.CartMenu;
+import com.my.foody.domain.menu.entity.Menu;
+import com.my.foody.global.jwt.JwtProvider;
+import com.my.foody.global.jwt.JwtVo;
+import com.my.foody.global.jwt.TokenSubject;
+import com.my.foody.global.jwt.UserType;
+import com.my.foody.global.util.DummyObject;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(CartController.class)
+@AutoConfigureMockMvc
+class CartControllerTest extends DummyObject {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockBean
+    private CartService cartService;
+    @MockBean
+    private JwtProvider jwtProvider;
+
+    @Test
+    @DisplayName("장바구니에 메뉴 추가 성공 테스트")
+    void addCartItem_Success() throws Exception {
+        // given
+        Long storeId = 1L;
+        Long menuId = 1L;
+        Long userId = 1L;
+        Long cartId = 1L;
+
+        String token = "test.token";
+        TokenSubject tokenSubject = new TokenSubject(userId, UserType.USER);
+        CartMenuCreateReqDto request = new CartMenuCreateReqDto(2L);
+        CartMenuCreateRespDto response = new CartMenuCreateRespDto(
+                CartMenu.builder()
+                        .cart(Cart.builder().id(cartId).build())
+                        .menu(Menu.builder().id(menuId).build())
+                        .quantity(2L)
+                        .build()
+        );
+
+        when(jwtProvider.validate(token)).thenReturn(tokenSubject);
+        when(cartService.addCartItem(eq(storeId), eq(menuId), any(CartMenuCreateReqDto.class), eq(userId)))
+                .thenReturn(response);
+
+        // when & then
+        String result = mockMvc.perform(post("/api/home/stores/{storeId}/menus/{menuId}", storeId, menuId)
+                        .header(JwtVo.HEADER, JwtVo.TOKEN_PREFIX + token)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.cartId").value(cartId))
+                .andExpect(jsonPath("$.data.menuId").value(menuId))
+                .andExpect(jsonPath("$.data.quantity").value(2))
+                .andDo(print())
+                .andReturn()
+                .getResponse()
+                .getContentAsString();
+    }
+
+    @Test
+    @DisplayName("장바구니에 메뉴 추가 실패 테스트:  잘못된 수량")
+    void addCartItem_InvalidQuantity() throws Exception {
+        // given
+        Long storeId = 1L;
+        Long menuId = 1L;
+        Long userId = 1L;
+        String token = "test.token";
+        TokenSubject tokenSubject = new TokenSubject(userId, UserType.USER);
+        CartMenuCreateReqDto request = new CartMenuCreateReqDto(-1L);
+
+        when(jwtProvider.validate(token)).thenReturn(tokenSubject);
+
+        // when & then
+        mockMvc.perform(post("/api/home/stores/{storeId}/menus/{menuId}", storeId, menuId)
+                        .header(JwtVo.HEADER, JwtVo.TOKEN_PREFIX + token)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request))
+                        .requestAttr("tokenSubject", tokenSubject))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.success").value(false))
+                .andExpect(jsonPath("$.apiError").exists());
+
+        verify(cartService, never()).addCartItem(anyLong(), anyLong(), any(), anyLong());
+    }
+
+
+}

--- a/src/test/java/com/my/foody/domain/cart/service/CartServiceTest.java
+++ b/src/test/java/com/my/foody/domain/cart/service/CartServiceTest.java
@@ -1,15 +1,15 @@
 package com.my.foody.domain.cart.service;
 
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.hibernate.validator.internal.util.Contracts.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.*;
 
 import com.my.foody.domain.cart.dto.req.CartMenuCreateReqDto;
-import com.my.foody.domain.cart.dto.resp.CartItemRespDto;
 import com.my.foody.domain.cart.dto.resp.CartMenuCreateRespDto;
 import com.my.foody.domain.cart.entity.Cart;
 import com.my.foody.domain.cart.repo.CartRepository;
-import java.util.Arrays;
+
 import java.util.Optional;
 
 import com.my.foody.domain.cartMenu.CartMenu;
@@ -20,19 +20,15 @@ import com.my.foody.domain.store.entity.Store;
 import com.my.foody.domain.store.service.StoreService;
 import com.my.foody.domain.user.entity.User;
 import com.my.foody.domain.user.service.UserService;
+import com.my.foody.global.ex.BusinessException;
+import com.my.foody.global.ex.ErrorCode;
 import com.my.foody.global.util.DummyObject;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageImpl;
-import org.springframework.data.domain.PageRequest;
-import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Sort;
 
 @ExtendWith(MockitoExtension.class)
 public class CartServiceTest extends DummyObject {
@@ -69,7 +65,7 @@ public class CartServiceTest extends DummyObject {
 
         when(userService.findActivateUserByIdOrFail(userId)).thenReturn(user);
         when(storeService.findActivateStoreByIdOrFail(storeId)).thenReturn(store);
-        when(menuService.findByIdOrFail(menuId)).thenReturn(menu);
+        when(menuService.findActiveMenuByIdOrFail(menuId)).thenReturn(menu);
         when(cartRepository.findByUser(user)).thenReturn(Optional.of(cart));
         when(cartMenuRepository.save(any(CartMenu.class))).thenReturn(cartMenu);
 
@@ -80,12 +76,134 @@ public class CartServiceTest extends DummyObject {
         assertNotNull(result);
         verify(userService).findActivateUserByIdOrFail(userId);
         verify(storeService).findActivateStoreByIdOrFail(storeId);
-        verify(menuService).findByIdOrFail(menuId);
+        verify(menuService).findActiveMenuByIdOrFail(menuId);
         verify(cartRepository).findByUser(user);
         verify(cartRepository, never()).save(any(Cart.class));
         verify(cartMenuRepository).save(any(CartMenu.class));
     }
 
+
+    @Test
+    @DisplayName("장바구니에 메뉴 추가 성공 테스트: 새로운 장바구니 생성")
+    void addCartItem_NewCart_Success() {
+        // given
+        Long userId = 1L;
+        Long storeId = 1L;
+        Long menuId = 1L;
+        CartMenuCreateReqDto request = new CartMenuCreateReqDto(2L);
+
+        User user = mock(User.class);
+        Store store = mock(Store.class);
+        Menu menu = mock(Menu.class);
+        Cart newCart = mock(Cart.class);
+        CartMenu cartMenu = mock(CartMenu.class);
+
+        when(userService.findActivateUserByIdOrFail(userId)).thenReturn(user);
+        when(storeService.findActivateStoreByIdOrFail(storeId)).thenReturn(store);
+        when(menuService.findActiveMenuByIdOrFail(menuId)).thenReturn(menu);
+        when(cartRepository.findByUser(user)).thenReturn(Optional.empty());
+        when(cartRepository.save(any(Cart.class))).thenReturn(newCart);
+        when(cartMenuRepository.save(any(CartMenu.class))).thenReturn(cartMenu);
+
+        // when
+        CartMenuCreateRespDto result = cartService.addCartItem(storeId, menuId, request, userId);
+
+        // then
+        assertNotNull(result);
+        verify(userService).findActivateUserByIdOrFail(userId);
+        verify(storeService).findActivateStoreByIdOrFail(storeId);
+        verify(menuService).findActiveMenuByIdOrFail(menuId);
+        verify(cartRepository).findByUser(user);
+        verify(cartRepository).save(any(Cart.class));
+        verify(cartMenuRepository).save(any(CartMenu.class));
+    }
+
+
+
+    @Test
+    @DisplayName("장바구니에 메뉴 추가 실패 테스트: 존재하지 않는 사용자")
+    void addCartItem_UserNotFound() {
+        // given
+        Long userId = 1L;
+        Long storeId = 1L;
+        Long menuId = 1L;
+        CartMenuCreateReqDto request = new CartMenuCreateReqDto(2L);
+
+        when(userService.findActivateUserByIdOrFail(userId))
+                .thenThrow(new BusinessException(ErrorCode.USER_NOT_FOUND));
+
+        // when & then
+        assertThatThrownBy(() ->
+                cartService.addCartItem(storeId, menuId, request, userId))
+                .isInstanceOf(BusinessException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.USER_NOT_FOUND);
+
+        verify(userService).findActivateUserByIdOrFail(userId);
+        verify(storeService, never()).findActivateStoreByIdOrFail(anyLong());
+        verify(menuService, never()).findActiveMenuByIdOrFail(anyLong());
+        verify(cartRepository, never()).findByUser(any(User.class));
+        verify(cartRepository, never()).save(any(Cart.class));
+        verify(cartMenuRepository, never()).save(any(CartMenu.class));
+    }
+
+
+    @Test
+    @DisplayName("장바구니에 메뉴 추가 실패 테스트: 존재하지 않는 가게")
+    void addCartItem_StoreNotFound() {
+        // given
+        Long userId = 1L;
+        Long storeId = 1L;
+        Long menuId = 1L;
+        CartMenuCreateReqDto request = new CartMenuCreateReqDto(2L);
+        User user = mock(User.class);
+
+        when(userService.findActivateUserByIdOrFail(userId)).thenReturn(user);
+        when(storeService.findActivateStoreByIdOrFail(storeId))
+                .thenThrow(new BusinessException(ErrorCode.STORE_NOT_FOUND));
+
+        // when & then
+        assertThatThrownBy(() ->
+                cartService.addCartItem(storeId, menuId, request, userId))
+                .isInstanceOf(BusinessException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.STORE_NOT_FOUND);
+
+        verify(userService).findActivateUserByIdOrFail(userId);
+        verify(storeService).findActivateStoreByIdOrFail(storeId);
+        verify(menuService, never()).findActiveMenuByIdOrFail(anyLong());
+        verify(cartRepository, never()).findByUser(any(User.class));
+        verify(cartMenuRepository, never()).save(any(CartMenu.class));
+    }
+
+
+    @Test
+    @DisplayName("장바구니에 메뉴 추가 실패 테스트:  품절된 메뉴")
+    void addCartItem_MenuNotAvailable() {
+        // given
+        Long userId = 1L;
+        Long storeId = 1L;
+        Long menuId = 1L;
+        CartMenuCreateReqDto request = new CartMenuCreateReqDto(2L);
+        User user = mock(User.class);
+        Store store = mock(Store.class);
+
+        when(userService.findActivateUserByIdOrFail(userId)).thenReturn(user);
+        when(storeService.findActivateStoreByIdOrFail(storeId)).thenReturn(store);
+        when(menuService.findActiveMenuByIdOrFail(menuId))
+                .thenThrow(new BusinessException(ErrorCode.MENU_NOT_AVAILABLE));
+
+        // when & then
+        assertThatThrownBy(() ->
+                cartService.addCartItem(storeId, menuId, request, userId))
+                .isInstanceOf(BusinessException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.MENU_NOT_AVAILABLE);
+
+        verify(userService).findActivateUserByIdOrFail(userId);
+        verify(storeService).findActivateStoreByIdOrFail(storeId);
+        verify(menuService).findActiveMenuByIdOrFail(menuId);
+        verify(cartRepository, never()).findByUser(any(User.class));
+        verify(cartRepository, never()).save(any(Cart.class));
+        verify(cartMenuRepository, never()).save(any(CartMenu.class));
+    }
 
 
 }

--- a/src/test/java/com/my/foody/domain/order/service/OrderServiceTest.java
+++ b/src/test/java/com/my/foody/domain/order/service/OrderServiceTest.java
@@ -72,9 +72,7 @@ public class OrderServiceTest extends DummyObject {
                 .build();
 
         cart = Cart.builder()
-                .quantity(2L)
                 .store(store)
-                .menu(menu)
                 .build();
     }
 
@@ -163,8 +161,6 @@ public class OrderServiceTest extends DummyObject {
         assertEquals(store.getId(), orderPreview.getStoreId());
         assertEquals(menu.getName(), orderPreview.getMenuName());
         assertEquals(menu.getPrice(), orderPreview.getMenuPrice());
-        assertEquals(cart.getQuantity(), orderPreview.getQuantity());
-        assertEquals(menu.getPrice() * cart.getQuantity(), orderPreview.getTotalAmount());
 
         // Verifying the interactions with the mocks
         verify(userRepository).findById(userId);


### PR DESCRIPTION
##전체  시나리오
1. 클라이언트가 메뉴를 선택 (menuId) / 한 번에 메뉴 한 개만 담을 수 있음
2. 토큰 검증
3. 유저 검증 -> 존재하지 않을 시 에러 throw
4. 가게 검증 -> 존재하지 않을 시 에러 throw
5. 메뉴 검증 -> 존재하지 않을 시 에러 throw
6. 이미 유저가 해당 가게에 대해 생성한 장바구니가 있는지 조회 -> 없다면 장바구니 객체 생성
7. 장바구니에 메뉴 담기
8. 응답으로 장바구니에 담긴 전체 메뉴 아이디, 메뉴 이름 반환

## 전체 리뷰 목록 조회 단위 테스트 추가
### **1. ✅ 장바구니에 메뉴 담기 성공**
    - 빈 장바구니에 메뉴 담을 때 케이스 검증
    - 기존 장바구니가 있을 때의 메뉴 담기 케이스 검증

### **2. ❌ 실패 케이스**
    - 존재하지 않는 사용자: USER_NOT_FOUND 검증
    - 잘못된 수량
    - 품절된 메뉴: MENU_NOT_AVAILABLE 검증
    - 존재하지 않는 가게: STORE_NOT_FOUND 검증
   
 