### PR TITLE
연동된 소셜 계정 조회 기능

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -49,6 +49,9 @@ dependencies {
 
     //jwt
     implementation group: 'com.auth0', name: 'java-jwt', version: '4.2.2'
+
+    //redis
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/my/foody/FoodyApplication.java
+++ b/src/main/java/com/my/foody/FoodyApplication.java
@@ -2,8 +2,10 @@ package com.my.foody;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cloud.openfeign.EnableFeignClients;
 
 @SpringBootApplication
+@EnableFeignClients
 public class FoodyApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/com/my/foody/domain/socialAccount/controller/SocialAccountController.java
+++ b/src/main/java/com/my/foody/domain/socialAccount/controller/SocialAccountController.java
@@ -1,6 +1,7 @@
 package com.my.foody.domain.socialAccount.controller;
 
 import com.my.foody.domain.socialAccount.dto.resp.LinkageTokenRespDto;
+import com.my.foody.domain.socialAccount.dto.resp.SocialAccountListRespDto;
 import com.my.foody.domain.socialAccount.dto.resp.SocialLoginRespDto;
 import com.my.foody.domain.socialAccount.entity.SocialAccount;
 import com.my.foody.domain.socialAccount.service.AccountLinkageService;
@@ -59,6 +60,12 @@ public class SocialAccountController {
         SocialLoginRespDto socialLoginRespDto = socialAccountService.processOAuth2Callback(provider, code);
         response.setHeader(JwtVo.HEADER, socialLoginRespDto.getToken());
         return new ResponseEntity<>(ApiResult.success(socialLoginRespDto), HttpStatus.OK);
+    }
+
+    @GetMapping("/api/users/mypage/social-accounts")
+    @RequireAuth(userType = UserType.USER)
+    public ResponseEntity<ApiResult<SocialAccountListRespDto>> getAllSocialAccount(@CurrentUser TokenSubject tokenSubject){
+        return new ResponseEntity<>(ApiResult.success(socialAccountService.getAllSocialAccount(tokenSubject.getId())), HttpStatus.OK);
     }
 
 }

--- a/src/main/java/com/my/foody/domain/socialAccount/controller/SocialAccountController.java
+++ b/src/main/java/com/my/foody/domain/socialAccount/controller/SocialAccountController.java
@@ -1,4 +1,9 @@
 package com.my.foody.domain.socialAccount.controller;
 
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
 public class SocialAccountController {
 }

--- a/src/main/java/com/my/foody/domain/socialAccount/controller/SocialAccountController.java
+++ b/src/main/java/com/my/foody/domain/socialAccount/controller/SocialAccountController.java
@@ -1,9 +1,62 @@
 package com.my.foody.domain.socialAccount.controller;
 
+import com.my.foody.domain.socialAccount.dto.resp.LinkageTokenRespDto;
+import com.my.foody.domain.socialAccount.dto.resp.SocialLoginRespDto;
+import com.my.foody.domain.socialAccount.entity.SocialAccount;
+import com.my.foody.domain.socialAccount.service.AccountLinkageService;
+import com.my.foody.domain.socialAccount.service.SocialAccountService;
+import com.my.foody.global.config.valid.CurrentUser;
+import com.my.foody.global.config.valid.RequireAuth;
+import com.my.foody.global.jwt.JwtVo;
+import com.my.foody.global.jwt.TokenSubject;
+import com.my.foody.global.jwt.UserType;
+import com.my.foody.global.util.api.ApiResult;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.io.IOException;
 
 @RestController
 @RequiredArgsConstructor
 public class SocialAccountController {
+
+    private final AccountLinkageService linkageService;
+    private final SocialAccountService socialAccountService;
+
+    //(이미 서버에 인증된 상태로 들어온 상황에서) 계정 연동 시작 -> 임시 토큰 생성
+    @RequireAuth(userType = UserType.USER)
+    @PostMapping("/api/account/link")
+    public ResponseEntity<ApiResult<LinkageTokenRespDto>> startAccountLinkage(@RequestParam(value = "provider")String provider, @CurrentUser TokenSubject tokenSubject){
+        return new ResponseEntity<>(ApiResult.success(linkageService.createLinkageToken(tokenSubject.getId(), provider)), HttpStatus.OK);
+    }
+
+    // 소셜 로그인 연동 시작 -> 인증 화면으로 갔다가 -> 콜백으로 연결
+    @GetMapping("/oauth2/authorization/{provider}")
+    public void socialLogin(@PathVariable(value = "provider")String provider,
+                            @RequestParam(required = false, value = "linkageToken") String linkageToken,
+                            HttpServletResponse response) throws IOException {
+        String authorizationUrl = socialAccountService.getAuthorizationUrl(provider, linkageToken);
+        response.sendRedirect(authorizationUrl);
+    }
+
+    // 소셜 로그인 콜백
+    @GetMapping("/login/oauth2/code/{provider}")
+    public ResponseEntity<ApiResult<SocialLoginRespDto>> callback(@PathVariable(value = "provider")String provider,
+                                                                  @RequestParam(value = "code")String code,
+                                                                  @RequestParam(required = false, value = "state")String state,
+                                                                  HttpServletResponse response){
+        //state(임시토큰) 값이 있으면 추가 소셜 계정 연동
+        if(state != null){
+            SocialLoginRespDto socialLoginRespDto = socialAccountService.processAccountLinkage(provider, code, state);
+            response.setHeader(JwtVo.HEADER, socialLoginRespDto.getToken());
+            return new ResponseEntity<>(ApiResult.success(socialLoginRespDto), HttpStatus.OK);
+        }
+        //일반 로그인 모드
+        return new ResponseEntity<>(ApiResult.success(socialAccountService.processOAuth2Callback(provider, code)), HttpStatus.OK);
+    }
+
 }

--- a/src/main/java/com/my/foody/domain/socialAccount/controller/SocialAccountController.java
+++ b/src/main/java/com/my/foody/domain/socialAccount/controller/SocialAccountController.java
@@ -56,7 +56,9 @@ public class SocialAccountController {
             return new ResponseEntity<>(ApiResult.success(socialLoginRespDto), HttpStatus.OK);
         }
         //일반 로그인 모드
-        return new ResponseEntity<>(ApiResult.success(socialAccountService.processOAuth2Callback(provider, code)), HttpStatus.OK);
+        SocialLoginRespDto socialLoginRespDto = socialAccountService.processOAuth2Callback(provider, code);
+        response.setHeader(JwtVo.HEADER, socialLoginRespDto.getToken());
+        return new ResponseEntity<>(ApiResult.success(socialLoginRespDto), HttpStatus.OK);
     }
 
 }

--- a/src/main/java/com/my/foody/domain/socialAccount/dto/resp/LinkageTokenRespDto.java
+++ b/src/main/java/com/my/foody/domain/socialAccount/dto/resp/LinkageTokenRespDto.java
@@ -1,0 +1,12 @@
+package com.my.foody.domain.socialAccount.dto.resp;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor
+@Getter
+@AllArgsConstructor
+public class LinkageTokenRespDto{
+    private String linkageToken;
+}

--- a/src/main/java/com/my/foody/domain/socialAccount/dto/resp/SocialAccountListRespDto.java
+++ b/src/main/java/com/my/foody/domain/socialAccount/dto/resp/SocialAccountListRespDto.java
@@ -1,0 +1,37 @@
+package com.my.foody.domain.socialAccount.dto.resp;
+
+import com.my.foody.domain.socialAccount.entity.SocialAccount;
+import com.my.foody.domain.user.entity.Provider;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@NoArgsConstructor
+@Getter
+public class SocialAccountListRespDto {
+
+    private List<SocialAccountRespDto> socialAccountList;g 
+    private int totalCount;
+
+    public SocialAccountListRespDto(List<SocialAccount> socialAccountList) {
+        this.socialAccountList = socialAccountList.stream()
+                .map(SocialAccountRespDto::new)
+                .toList();
+        this.totalCount = socialAccountList.size();
+    }
+
+    @NoArgsConstructor
+    @Getter
+    public static class SocialAccountRespDto{
+        public SocialAccountRespDto(SocialAccount socialAccount) {
+            this.socialAccountId = socialAccount.getId();
+            this.provider = socialAccount.getProvider();
+            this.email = socialAccount.getEmail();
+        }
+
+        private Long socialAccountId;
+        private Provider provider;
+        private String email;
+    }
+}

--- a/src/main/java/com/my/foody/domain/socialAccount/dto/resp/SocialAccountListRespDto.java
+++ b/src/main/java/com/my/foody/domain/socialAccount/dto/resp/SocialAccountListRespDto.java
@@ -11,7 +11,7 @@ import java.util.List;
 @Getter
 public class SocialAccountListRespDto {
 
-    private List<SocialAccountRespDto> socialAccountList;g 
+    private List<SocialAccountRespDto> socialAccountList;
     private int totalCount;
 
     public SocialAccountListRespDto(List<SocialAccount> socialAccountList) {

--- a/src/main/java/com/my/foody/domain/socialAccount/dto/resp/SocialLoginRespDto.java
+++ b/src/main/java/com/my/foody/domain/socialAccount/dto/resp/SocialLoginRespDto.java
@@ -11,9 +11,6 @@ import lombok.NoArgsConstructor;
 @Getter
 public class SocialLoginRespDto {
     private Long userId;
-    private String userEmail;
-    private String userNickname;
-
     private String socialEmail;
     private String socialNickname;
     private Provider provider;
@@ -22,8 +19,6 @@ public class SocialLoginRespDto {
 
     public SocialLoginRespDto(User user, SocialAccount socialAccount, String token) {
         this.userId = user.getId();
-        this.userEmail = user.getEmail();
-        this.userNickname = user.getNickname();
         this.socialEmail = socialAccount.getEmail();
         this.socialNickname = socialAccount.getNickname();
         this.provider = socialAccount.getProvider();

--- a/src/main/java/com/my/foody/domain/socialAccount/dto/resp/SocialLoginRespDto.java
+++ b/src/main/java/com/my/foody/domain/socialAccount/dto/resp/SocialLoginRespDto.java
@@ -1,0 +1,32 @@
+package com.my.foody.domain.socialAccount.dto.resp;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.my.foody.domain.socialAccount.entity.SocialAccount;
+import com.my.foody.domain.user.entity.Provider;
+import com.my.foody.domain.user.entity.User;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor
+@Getter
+public class SocialLoginRespDto {
+    private Long userId;
+    private String userEmail;
+    private String userNickname;
+
+    private String socialEmail;
+    private String socialNickname;
+    private Provider provider;
+    @JsonIgnore
+    private String token;
+
+    public SocialLoginRespDto(User user, SocialAccount socialAccount, String token) {
+        this.userId = user.getId();
+        this.userEmail = user.getEmail();
+        this.userNickname = user.getNickname();
+        this.socialEmail = socialAccount.getEmail();
+        this.socialNickname = socialAccount.getNickname();
+        this.provider = socialAccount.getProvider();
+        this.token = token;
+    }
+}

--- a/src/main/java/com/my/foody/domain/socialAccount/entity/SocialAccount.java
+++ b/src/main/java/com/my/foody/domain/socialAccount/entity/SocialAccount.java
@@ -4,9 +4,7 @@ import com.my.foody.domain.base.BaseEntity;
 import com.my.foody.domain.user.entity.Provider;
 import com.my.foody.domain.user.entity.User;
 import jakarta.persistence.*;
-import lombok.AccessLevel;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 @Entity
 @Getter
@@ -17,6 +15,8 @@ import lombok.NoArgsConstructor;
                 columnNames = {"provider", "providerId"}
         )
 })
+@AllArgsConstructor
+@Builder
 public class SocialAccount extends BaseEntity {
 
     @Id

--- a/src/main/java/com/my/foody/domain/socialAccount/repo/SocialAccountRepository.java
+++ b/src/main/java/com/my/foody/domain/socialAccount/repo/SocialAccountRepository.java
@@ -1,9 +1,18 @@
 package com.my.foody.domain.socialAccount.repo;
 
 import com.my.foody.domain.socialAccount.entity.SocialAccount;
+import com.my.foody.domain.user.entity.Provider;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
+
 @Repository
 public interface SocialAccountRepository extends JpaRepository<SocialAccount, Long> {
+
+    boolean existsByProviderAndUserId(Provider provider, Long userId);
+
+    boolean existsByProviderAndProviderId(Provider provider, String providerId);
+
+    Optional<SocialAccount> findByProviderAndProviderId(Provider provider, String providerId);
 }

--- a/src/main/java/com/my/foody/domain/socialAccount/repo/SocialAccountRepository.java
+++ b/src/main/java/com/my/foody/domain/socialAccount/repo/SocialAccountRepository.java
@@ -2,9 +2,11 @@ package com.my.foody.domain.socialAccount.repo;
 
 import com.my.foody.domain.socialAccount.entity.SocialAccount;
 import com.my.foody.domain.user.entity.Provider;
+import com.my.foody.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 
 @Repository
@@ -15,4 +17,6 @@ public interface SocialAccountRepository extends JpaRepository<SocialAccount, Lo
     boolean existsByProviderAndProviderId(Provider provider, String providerId);
 
     Optional<SocialAccount> findByProviderAndProviderId(Provider provider, String providerId);
+
+    List<SocialAccount> findByUser(User user);
 }

--- a/src/main/java/com/my/foody/domain/socialAccount/service/AccountLinkageService.java
+++ b/src/main/java/com/my/foody/domain/socialAccount/service/AccountLinkageService.java
@@ -20,6 +20,15 @@ public class AccountLinkageService {
     private static final long TOKEN_VALID_TIME = 5; //5분으로 설정
     private final SocialAccountRepository socialAccountRepository;
 
+    public void validateLinkageToken(String linkageToken){
+        String redisKey = TEMPORAL_TOKEN_PREFIX + linkageToken;
+        String userId = redisTemplate.opsForValue().get(redisKey);
+
+        if (userId == null) {
+            throw new BusinessException(ErrorCode.EXPIRED_LINKAGE_TOKEN);
+        }
+    }
+
     public LinkageTokenRespDto createLinkageToken(Long userId, String provider){
 
         //이미 해당 provider로 연동된 계정이 있는지 확인
@@ -46,7 +55,7 @@ public class AccountLinkageService {
         String userId = redisTemplate.opsForValue().get(redisKey);
 
         if(userId == null){
-            throw new BusinessException(ErrorCode.EXPIRED_TEMPORARY_TOKEN);
+            throw new BusinessException(ErrorCode.EXPIRED_LINKAGE_TOKEN);
         }
         redisTemplate.delete(redisKey);
         return Long.parseLong(userId);

--- a/src/main/java/com/my/foody/domain/socialAccount/service/AccountLinkageService.java
+++ b/src/main/java/com/my/foody/domain/socialAccount/service/AccountLinkageService.java
@@ -1,0 +1,54 @@
+package com.my.foody.domain.socialAccount.service;
+
+import com.my.foody.domain.socialAccount.dto.resp.LinkageTokenRespDto;
+import com.my.foody.domain.socialAccount.repo.SocialAccountRepository;
+import com.my.foody.domain.user.entity.Provider;
+import com.my.foody.global.ex.BusinessException;
+import com.my.foody.global.ex.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+
+@RequiredArgsConstructor
+@Service
+public class AccountLinkageService {
+    private final RedisTemplate<String, String> redisTemplate;
+    private static final String TEMPORAL_TOKEN_PREFIX = "link:";
+    private static final long TOKEN_VALID_TIME = 5; //5분으로 설정
+    private final SocialAccountRepository socialAccountRepository;
+
+    public LinkageTokenRespDto createLinkageToken(Long userId, String provider){
+
+        //이미 해당 provider로 연동된 계정이 있는지 확인
+        if(socialAccountRepository.existsByProviderAndUserId(Provider.fromString(provider), userId)){
+            throw new BusinessException(ErrorCode.ALREADY_LINKED_OAUTH);
+        }
+
+        String token = UUID.randomUUID().toString();
+        String redisKey = TEMPORAL_TOKEN_PREFIX + token;
+
+        //임시 토큰
+        redisTemplate.opsForValue().set(
+                redisKey,
+                userId.toString(),
+                TOKEN_VALID_TIME,
+                TimeUnit.MINUTES
+        );
+
+        return new LinkageTokenRespDto(token);
+    }
+
+    public Long getUserIdFromToken(String token){
+        String redisKey = TEMPORAL_TOKEN_PREFIX + token;
+        String userId = redisTemplate.opsForValue().get(redisKey);
+
+        if(userId == null){
+            throw new BusinessException(ErrorCode.EXPIRED_TEMPORARY_TOKEN);
+        }
+        redisTemplate.delete(redisKey);
+        return Long.parseLong(userId);
+    }
+}

--- a/src/main/java/com/my/foody/domain/socialAccount/service/SocialAccountService.java
+++ b/src/main/java/com/my/foody/domain/socialAccount/service/SocialAccountService.java
@@ -99,7 +99,7 @@ public class SocialAccountService {
         //소셜 계정 정보로 기존 연동 정보 조회
         SocialAccount socialAccount = socialAccountRepository.findByProviderAndProviderId(provider, userInfo.getProviderId())
                 .orElseThrow(() -> new BusinessException(ErrorCode.SOCIAL_ACCOUNT_NOT_FOUND));
-        User user = socialAccount.getUser();
+        User user = userService.findActivateUserByIdOrFail(socialAccount.getUser().getId());
 
         if (user.getIsDeleted()) {
             throw new BusinessException(ErrorCode.ALREADY_DEACTIVATED_USER);

--- a/src/main/java/com/my/foody/domain/socialAccount/service/SocialAccountService.java
+++ b/src/main/java/com/my/foody/domain/socialAccount/service/SocialAccountService.java
@@ -1,4 +1,136 @@
 package com.my.foody.domain.socialAccount.service;
 
+import com.my.foody.domain.socialAccount.dto.resp.SocialLoginRespDto;
+import com.my.foody.domain.socialAccount.entity.SocialAccount;
+import com.my.foody.domain.socialAccount.repo.SocialAccountRepository;
+import com.my.foody.domain.user.dto.req.UserLoginReqDto;
+import com.my.foody.domain.user.entity.Provider;
+import com.my.foody.domain.user.entity.User;
+import com.my.foody.domain.user.repo.UserRepository;
+import com.my.foody.domain.user.service.UserService;
+import com.my.foody.global.ex.BusinessException;
+import com.my.foody.global.ex.ErrorCode;
+import com.my.foody.global.jwt.JwtProvider;
+import com.my.foody.global.jwt.TokenSubject;
+import com.my.foody.global.util.api.ApiResult;
+import com.my.foody.infra.oauth.common.*;
+import com.my.foody.infra.oauth.dto.TokenRespDto;
+import feign.FeignException;
+import lombok.RequiredArgsConstructor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+import org.springframework.web.util.UriComponentsBuilder;
+
+@Service
+@RequiredArgsConstructor
 public class SocialAccountService {
+
+    private final OAuth2Properties oAuth2Properties;
+    private final OAuth2ClientFactory oAuth2ClientFactory;
+    private final UserService userService;
+    private final AccountLinkageService linkageService;
+    private final SocialAccountRepository socialAccountRepository;
+    private final JwtProvider jwtProvider;
+    private final UserRepository userRepository;
+
+    private final Logger log = LoggerFactory.getLogger(this.getClass());
+
+    private static final String RESPONSE_TYPE = "code";
+    public String getAuthorizationUrl(String provider, String linkageToken) {
+        OAuth2Provider oAuth2Provider = oAuth2Properties.getProvider(provider);
+        UriComponentsBuilder builder = UriComponentsBuilder
+                .fromUriString(oAuth2Provider.getAuthorizationUri())
+                .queryParam("client_id", oAuth2Provider.getClientId())
+                .queryParam("redirect_uri", oAuth2Provider.getRedirectUri())
+                .queryParam("response_type", RESPONSE_TYPE)
+                .queryParam("scope", String.join(" ", oAuth2Provider.getScopes()));
+
+        if(linkageToken != null){
+            builder.queryParam("state", linkageToken);
+        }
+        return builder.build().toUriString();
+    }
+
+    //계정 연동 처리
+    public SocialLoginRespDto processAccountLinkage(String provider, String code, String linkageToken) {
+        try {
+            //토큰으로 기존 사용자 확인
+            Long userId = linkageService.getUserIdFromToken(linkageToken);
+
+            //oauth2 인증 처리
+            OAuth2Client<? extends TokenRespDto> client = oAuth2ClientFactory.getClient(provider);
+            TokenRespDto tokenRespDto = client.getAccessToken(code);
+            OAuth2UserInfo userInfo = client.getUserInfo(tokenRespDto.getAccessToken());
+
+            //계정 연동 처리
+            return userService.linkAccount(userId, userInfo, Provider.fromString(provider));
+        } catch (FeignException e) {
+            log.error("OAuth2 계정 연동 프로세스 실패 - provider: {}, linkageToken: {}, error: {}",
+                    provider, linkageToken, e.getMessage());
+            throw new IllegalStateException("OAuth2 계정 연동 실패: {}" + e.getMessage(), e);
+        }
+    }
+
+    //일반 로그인 처리
+    public SocialLoginRespDto processOAuth2Callback(String provider, String code){
+        OAuth2Client<? extends TokenRespDto> client = oAuth2ClientFactory.getClient(provider);
+        try{
+            TokenRespDto tokenRespDto = client.getAccessToken(code);
+            OAuth2UserInfo userInfo = client.getUserInfo(tokenRespDto.getAccessToken());
+            // 소셜 계정 존재 여부 확인
+            try {
+                // 기존 소셜 계정으로 로그인 시도
+                return loginWithSocialAccount(userInfo, Provider.fromString(provider));
+            } catch (BusinessException e) {
+                if (e.getErrorCode() == ErrorCode.SOCIAL_ACCOUNT_NOT_FOUND) { //소셜 계정이 없는 경우 새로 가입
+                    return registerWithSocialAccount(userInfo, Provider.fromString(provider));
+                }
+                throw e;
+            }
+        }catch (FeignException e){
+            log.error("OAuth2 프로세스 실패 - provider: {}, error: {}", provider, e.getMessage());
+            throw new IllegalStateException("OAuth2 콜백 실패: {}"+e.getMessage(), e);
+        }
+    }
+
+    //소셜 계정을 통한 로그인
+    public SocialLoginRespDto loginWithSocialAccount(OAuth2UserInfo userInfo, Provider provider) {
+        //소셜 계정 정보로 기존 연동 정보 조회
+        SocialAccount socialAccount = socialAccountRepository.findByProviderAndProviderId(provider, userInfo.getProviderId())
+                .orElseThrow(() -> new BusinessException(ErrorCode.SOCIAL_ACCOUNT_NOT_FOUND));
+        User user = socialAccount.getUser();
+
+        if (user.getIsDeleted()) {
+            throw new BusinessException(ErrorCode.ALREADY_DEACTIVATED_USER);
+        }
+
+        String token = jwtProvider.create(TokenSubject.of(user));
+        return new SocialLoginRespDto(user, socialAccount, token);
+    }
+
+    // 소셜 계정으로 최초 가입 (소셜 계정이 없는 경우)
+    public SocialLoginRespDto registerWithSocialAccount(OAuth2UserInfo userInfo, Provider provider) {
+
+        User user = userInfo.toEntity();
+        userRepository.save(user);
+
+        //SocialAccount 생성 및 연동
+        SocialAccount socialAccount = createSocialAccount(user, provider, userInfo);
+        socialAccountRepository.save(socialAccount);
+
+        String token = jwtProvider.create(TokenSubject.of(user));
+        return new SocialLoginRespDto(user, socialAccount, token);
+    }
+
+    public SocialAccount createSocialAccount(User user, Provider provider, OAuth2UserInfo userInfo){
+        return SocialAccount.builder()
+                .user(user)
+                .providerId(userInfo.getProviderId())
+                .provider(provider)
+                .email(userInfo.getEmail())
+                .nickname(userInfo.getName())
+                .name(userInfo.getName())
+                .build();
+    }
 }

--- a/src/main/java/com/my/foody/domain/user/entity/Provider.java
+++ b/src/main/java/com/my/foody/domain/user/entity/Provider.java
@@ -1,5 +1,13 @@
 package com.my.foody.domain.user.entity;
 
 public enum Provider {
-    GOOGLE, KAKAO
+    GOOGLE, KAKAO;
+
+    public static Provider fromString(String str) {
+        try {
+            return Provider.valueOf(str.toUpperCase());
+        } catch (IllegalArgumentException e) {
+            throw new IllegalArgumentException("존재하지 않는 provider: " + str);
+        }
+    }
 }

--- a/src/main/java/com/my/foody/domain/user/service/UserService.java
+++ b/src/main/java/com/my/foody/domain/user/service/UserService.java
@@ -155,7 +155,7 @@ public class UserService {
         User user = findActivateUserByIdOrFail(userId);
 
         //이미 연동된 소셜 계정인지 확인
-        if(!socialAccountRepository.existsByProviderAndProviderId(provider, userInfo.getProviderId())){
+        if(socialAccountRepository.existsByProviderAndProviderId(provider, userInfo.getProviderId())){
             throw new BusinessException(ErrorCode.ALREADY_LINKED_OAUTH);
         }
 

--- a/src/main/java/com/my/foody/domain/user/service/UserService.java
+++ b/src/main/java/com/my/foody/domain/user/service/UserService.java
@@ -6,6 +6,9 @@ import com.my.foody.domain.address.dto.resp.AddressCreateRespDto;
 import com.my.foody.domain.address.dto.resp.AddressModifyRespDto;
 import com.my.foody.domain.address.entity.Address;
 import com.my.foody.domain.address.repo.AddressRepository;
+import com.my.foody.domain.socialAccount.dto.resp.SocialLoginRespDto;
+import com.my.foody.domain.socialAccount.entity.SocialAccount;
+import com.my.foody.domain.socialAccount.repo.SocialAccountRepository;
 import com.my.foody.domain.user.dto.req.UserDeleteReqDto;
 import com.my.foody.domain.user.dto.req.UserInfoModifyReqDto;
 import com.my.foody.domain.user.dto.req.UserLoginReqDto;
@@ -14,12 +17,14 @@ import com.my.foody.domain.user.dto.req.UserSignUpReqDto;
 import com.my.foody.domain.user.dto.resp.*;
 import com.my.foody.domain.user.dto.resp.UserInfoModifyRespDto;
 import com.my.foody.domain.address.service.AddressService;
+import com.my.foody.domain.user.entity.Provider;
 import com.my.foody.domain.user.entity.User;
 import com.my.foody.domain.user.repo.UserRepository;
 import com.my.foody.global.ex.BusinessException;
 import com.my.foody.global.ex.ErrorCode;
 import com.my.foody.global.jwt.JwtProvider;
 import com.my.foody.global.jwt.TokenSubject;
+import com.my.foody.infra.oauth.common.OAuth2UserInfo;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -36,6 +41,7 @@ public class UserService {
     private final AddressRepository addressRepository;
     private final AddressService addressService;
     private final JwtProvider jwtProvider;
+    private final SocialAccountRepository socialAccountRepository;
 
     public UserSignUpRespDto signUp(UserSignUpReqDto userSignUpReqDto){
         //이메일 중복 검사
@@ -143,4 +149,28 @@ public class UserService {
         List<Address> addressList = addressRepository.findAllByUserOrderByCreatedAtDesc(user);
         return new AddressListRespDto(addressList);
     }
+
+    public SocialLoginRespDto linkAccount(Long userId, OAuth2UserInfo userInfo, Provider provider) {
+        //기존 사용자 확인
+        User user = findActivateUserByIdOrFail(userId);
+
+        //이미 연동된 소셜 계정인지 확인
+        if(!socialAccountRepository.existsByProviderAndProviderId(provider, userInfo.getProviderId())){
+            throw new BusinessException(ErrorCode.ALREADY_LINKED_OAUTH);
+        }
+
+        //새로운 소셜 계정 연동
+        SocialAccount socialAccount = SocialAccount.builder()
+                .user(user)
+                .providerId(userInfo.getProviderId())
+                .provider(provider)
+                .email(userInfo.getEmail())
+                .nickname(userInfo.getName())
+                .name(userInfo.getName())
+                .build();
+        socialAccountRepository.save(socialAccount);
+        String token = jwtProvider.create(TokenSubject.of(user));
+        return new SocialLoginRespDto(user, socialAccount, token);
+    }
+
 }

--- a/src/main/java/com/my/foody/global/config/WebMvcConfig.java
+++ b/src/main/java/com/my/foody/global/config/WebMvcConfig.java
@@ -23,6 +23,12 @@ public class WebMvcConfig implements WebMvcConfigurer {
     @Override
     public void addInterceptors(InterceptorRegistry registry) {
         registry.addInterceptor(authInterceptor)
-                .addPathPatterns("/**");
+                .addPathPatterns("/**")
+                .excludePathPatterns(
+                        "/oauth2/authorization/**",
+                        "/login/oauth2/code/**",
+                        "/error",
+                        "/favicon.ico"
+                );
     }
 }

--- a/src/main/java/com/my/foody/global/ex/ErrorCode.java
+++ b/src/main/java/com/my/foody/global/ex/ErrorCode.java
@@ -31,8 +31,9 @@ public enum ErrorCode {
     OWNER_NOT_FOUND(HttpStatus.NOT_FOUND.value(), "OWNER를 찾을 수 없습니다."),
     CATEGORY_NOT_FOUND(HttpStatus.NOT_FOUND.value(), "존재하지 않는 카테고리입니다."),
     ALREADY_LINKED_OAUTH(HttpStatus.BAD_REQUEST.value(), "이미 연동된 소셜 계정입니다"),
-    EXPIRED_TEMPORARY_TOKEN(HttpStatus.UNAUTHORIZED.value(), "만료된 임시 토큰입니다"),
+    EXPIRED_LINKAGE_TOKEN(HttpStatus.UNAUTHORIZED.value(), "만료된 임시 토큰입니다"),
     SOCIAL_ACCOUNT_NOT_FOUND(HttpStatus.BAD_REQUEST.value(), "연동된 소셜 계정을 찾을 수 없습니다"),
+    UNSUPPORTED_OAUTH_PROVIDER(HttpStatus.BAD_REQUEST.value(), "지원하지 않는 Oauth2 입니다"),
     ;
 
 

--- a/src/main/java/com/my/foody/global/ex/ErrorCode.java
+++ b/src/main/java/com/my/foody/global/ex/ErrorCode.java
@@ -37,7 +37,8 @@ public enum ErrorCode {
     SOCIAL_ACCOUNT_NOT_FOUND(HttpStatus.BAD_REQUEST.value(), "연동된 소셜 계정을 찾을 수 없습니다"),
     UNSUPPORTED_OAUTH_PROVIDER(HttpStatus.BAD_REQUEST.value(), "지원하지 않는 Oauth2 입니다"),
     MENU_NOT_FOUND(HttpStatus.BAD_REQUEST.value(), "존재하지 않는 메뉴입니다"),
-    MENU_NOT_AVAILABLE(HttpStatus.BAD_REQUEST.value(), "현재 주문할 수 없는 메뉴입니다");
+    MENU_NOT_AVAILABLE(HttpStatus.BAD_REQUEST.value(), "현재 주문할 수 없는 메뉴입니다"),
+    OAUTH_CALLBACK_FAILED(HttpStatus.INTERNAL_SERVER_ERROR.value(), "소셜 인증 서버와 통신 중 오류가 발생했습니다");
 
 
     private final int status;

--- a/src/main/java/com/my/foody/global/ex/ErrorCode.java
+++ b/src/main/java/com/my/foody/global/ex/ErrorCode.java
@@ -30,6 +30,9 @@ public enum ErrorCode {
     HAVE_FULL_STORE(HttpStatus.CONFLICT.value(), "생성 가능한 가게 수를 초과합니다."),
     OWNER_NOT_FOUND(HttpStatus.NOT_FOUND.value(), "OWNER를 찾을 수 없습니다."),
     CATEGORY_NOT_FOUND(HttpStatus.NOT_FOUND.value(), "존재하지 않는 카테고리입니다."),
+    ALREADY_LINKED_OAUTH(HttpStatus.BAD_REQUEST.value(), "이미 연동된 소셜 계정입니다"),
+    EXPIRED_TEMPORARY_TOKEN(HttpStatus.UNAUTHORIZED.value(), "만료된 임시 토큰입니다"),
+    SOCIAL_ACCOUNT_NOT_FOUND(HttpStatus.BAD_REQUEST.value(), "연동된 소셜 계정을 찾을 수 없습니다"),
     ;
 
 

--- a/src/main/java/com/my/foody/infra/oauth/common/OAuth2Client.java
+++ b/src/main/java/com/my/foody/infra/oauth/common/OAuth2Client.java
@@ -1,0 +1,6 @@
+package com.my.foody.infra.oauth.common;
+
+public interface OAuth2Client<T> {
+    T getAccessToken(String code);
+    OAuth2UserInfo getUserInfo(String accessToken);
+}

--- a/src/main/java/com/my/foody/infra/oauth/common/OAuth2ClientFactory.java
+++ b/src/main/java/com/my/foody/infra/oauth/common/OAuth2ClientFactory.java
@@ -1,0 +1,35 @@
+package com.my.foody.infra.oauth.common;
+
+import com.my.foody.infra.oauth.dto.TokenRespDto;
+import com.my.foody.infra.oauth.dto.kakao.KakaoTokenRespDto;
+import com.my.foody.infra.oauth.kakao.KakaoApiClient;
+import com.my.foody.infra.oauth.kakao.KakaoAuthClient;
+import com.my.foody.infra.oauth.kakao.KakaoOAuth2Client;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@RequiredArgsConstructor
+@Component
+public class OAuth2ClientFactory {
+
+    private final KakaoAuthClient kakaoAuthClient;
+    private final KakaoApiClient kakaoApiClient;
+    private final OAuth2Properties oAuth2Properties;
+
+    public OAuth2Client<? extends TokenRespDto> getClient(String provider){
+        if(provider.equalsIgnoreCase("kakao")){
+            return getKakaoClient();
+        }
+        throw new IllegalStateException("지원하지 않는 OAuth2 provider 입니다: " + provider);
+    }
+
+    public OAuth2Client<KakaoTokenRespDto> getKakaoClient(){
+        return new KakaoOAuth2Client(
+                kakaoAuthClient,
+                kakaoApiClient,
+                oAuth2Properties.getProvider("kakao")
+        );
+    }
+
+
+}

--- a/src/main/java/com/my/foody/infra/oauth/common/OAuth2ClientFactory.java
+++ b/src/main/java/com/my/foody/infra/oauth/common/OAuth2ClientFactory.java
@@ -1,7 +1,13 @@
 package com.my.foody.infra.oauth.common;
 
+import com.my.foody.global.ex.BusinessException;
+import com.my.foody.global.ex.ErrorCode;
 import com.my.foody.infra.oauth.dto.TokenRespDto;
+import com.my.foody.infra.oauth.dto.google.GoogleTokenRespDto;
 import com.my.foody.infra.oauth.dto.kakao.KakaoTokenRespDto;
+import com.my.foody.infra.oauth.google.GoogleApiClient;
+import com.my.foody.infra.oauth.google.GoogleAuthClient;
+import com.my.foody.infra.oauth.google.GoogleOAuth2Client;
 import com.my.foody.infra.oauth.kakao.KakaoApiClient;
 import com.my.foody.infra.oauth.kakao.KakaoAuthClient;
 import com.my.foody.infra.oauth.kakao.KakaoOAuth2Client;
@@ -12,6 +18,9 @@ import org.springframework.stereotype.Component;
 @Component
 public class OAuth2ClientFactory {
 
+    private final GoogleAuthClient googleAuthClient;
+    private final GoogleApiClient googleApiClient;
+
     private final KakaoAuthClient kakaoAuthClient;
     private final KakaoApiClient kakaoApiClient;
     private final OAuth2Properties oAuth2Properties;
@@ -20,7 +29,10 @@ public class OAuth2ClientFactory {
         if(provider.equalsIgnoreCase("kakao")){
             return getKakaoClient();
         }
-        throw new IllegalStateException("지원하지 않는 OAuth2 provider 입니다: " + provider);
+        else if(provider.equalsIgnoreCase("google")){
+            return getGoogleClient();
+        }
+        throw new BusinessException(ErrorCode.UNSUPPORTED_OAUTH_PROVIDER);
     }
 
     public OAuth2Client<KakaoTokenRespDto> getKakaoClient(){
@@ -28,6 +40,14 @@ public class OAuth2ClientFactory {
                 kakaoAuthClient,
                 kakaoApiClient,
                 oAuth2Properties.getProvider("kakao")
+        );
+    }
+
+    public OAuth2Client<GoogleTokenRespDto> getGoogleClient() {
+        return new GoogleOAuth2Client(
+                googleAuthClient,
+                googleApiClient,
+                oAuth2Properties.getProvider("google")
         );
     }
 

--- a/src/main/java/com/my/foody/infra/oauth/common/OAuth2Properties.java
+++ b/src/main/java/com/my/foody/infra/oauth/common/OAuth2Properties.java
@@ -1,0 +1,20 @@
+package com.my.foody.infra.oauth.common;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+import java.util.Map;
+
+@Getter
+@Setter
+@Component
+@ConfigurationProperties(prefix = "oauth2")
+public class OAuth2Properties {
+    private Map<String, OAuth2Provider> providers;
+
+    public OAuth2Provider getProvider(String provider){
+        return providers.get(provider);
+    }
+}

--- a/src/main/java/com/my/foody/infra/oauth/common/OAuth2Provider.java
+++ b/src/main/java/com/my/foody/infra/oauth/common/OAuth2Provider.java
@@ -1,0 +1,18 @@
+package com.my.foody.infra.oauth.common;
+
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.List;
+
+@Getter
+@Setter
+public class OAuth2Provider {
+    private String clientId;
+    private String clientSecret;
+    private String redirectUri;
+    private String authorizationUri;
+    private String tokenUri;
+    private String userInfoUri;
+    private List<String> scopes;
+}

--- a/src/main/java/com/my/foody/infra/oauth/common/OAuth2UserInfo.java
+++ b/src/main/java/com/my/foody/infra/oauth/common/OAuth2UserInfo.java
@@ -1,0 +1,7 @@
+package com.my.foody.infra.oauth.common;
+
+public interface OAuth2UserInfo {
+    String getProviderId();
+    String getEmail();
+    String getName();
+}

--- a/src/main/java/com/my/foody/infra/oauth/common/OAuth2UserInfo.java
+++ b/src/main/java/com/my/foody/infra/oauth/common/OAuth2UserInfo.java
@@ -1,7 +1,11 @@
 package com.my.foody.infra.oauth.common;
 
+import com.my.foody.domain.user.entity.User;
+
 public interface OAuth2UserInfo {
     String getProviderId();
     String getEmail();
     String getName();
+
+    User toEntity();
 }

--- a/src/main/java/com/my/foody/infra/oauth/config/OAuthFeignConfig.java
+++ b/src/main/java/com/my/foody/infra/oauth/config/OAuthFeignConfig.java
@@ -1,0 +1,34 @@
+package com.my.foody.infra.oauth.config;
+
+import feign.codec.Decoder;
+import feign.codec.Encoder;
+import feign.jackson.JacksonDecoder;
+import feign.jackson.JacksonEncoder;
+import okhttp3.OkHttpClient;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.util.concurrent.TimeUnit;
+
+@Configuration
+public class OAuthFeignConfig {
+
+    @Bean
+    public OkHttpClient client() {
+        return new OkHttpClient.Builder()
+                .connectTimeout(60, TimeUnit.SECONDS)
+                .readTimeout(60, TimeUnit.SECONDS)
+                .writeTimeout(60, TimeUnit.SECONDS)
+                .build();
+    }
+
+    @Bean
+    public Decoder decoder() {
+        return new JacksonDecoder();
+    }
+
+    @Bean
+    public Encoder encoder() {
+        return new JacksonEncoder();
+    }
+}

--- a/src/main/java/com/my/foody/infra/oauth/dto/TokenRespDto.java
+++ b/src/main/java/com/my/foody/infra/oauth/dto/TokenRespDto.java
@@ -1,0 +1,5 @@
+package com.my.foody.infra.oauth.dto;
+
+public interface TokenRespDto {
+    String getAccessToken();
+}

--- a/src/main/java/com/my/foody/infra/oauth/dto/google/GoogleTokenRespDto.java
+++ b/src/main/java/com/my/foody/infra/oauth/dto/google/GoogleTokenRespDto.java
@@ -1,0 +1,27 @@
+package com.my.foody.infra.oauth.dto.google;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.my.foody.infra.oauth.dto.TokenRespDto;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor
+@Getter
+public class GoogleTokenRespDto implements TokenRespDto {
+
+    //google api 호출 시 사용하는 토큰
+    @JsonProperty("access_token")
+    private String accessToken;
+
+    //토큰 만료 시간
+    @JsonProperty("expires_in")
+    private Integer expiresIn;
+
+    //Bearer 타입
+    @JsonProperty("token_type")
+    private String tokenType;
+
+    //허용된 권한
+    @JsonProperty("scope")
+    private String scope;
+}

--- a/src/main/java/com/my/foody/infra/oauth/dto/google/GoogleUserInfo.java
+++ b/src/main/java/com/my/foody/infra/oauth/dto/google/GoogleUserInfo.java
@@ -1,0 +1,29 @@
+package com.my.foody.infra.oauth.dto.google;
+
+import com.my.foody.domain.user.entity.User;
+import com.my.foody.infra.oauth.common.OAuth2UserInfo;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class GoogleUserInfo implements OAuth2UserInfo {
+    private String id;
+    private String email;
+    private String name;
+
+    @Override
+    public String getProviderId() {
+        return id;
+    }
+
+    @Override
+    public User toEntity() {
+        return User.builder()
+                .email(getEmail())
+                .nickname(getName())
+                .name(getName())
+                .isDeleted(false)
+                .build();
+    }
+}

--- a/src/main/java/com/my/foody/infra/oauth/dto/kakao/KakaoAccountDto.java
+++ b/src/main/java/com/my/foody/infra/oauth/dto/kakao/KakaoAccountDto.java
@@ -1,0 +1,27 @@
+package com.my.foody.infra.oauth.dto.kakao;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor
+@Getter
+public class KakaoAccountDto{
+
+    @JsonProperty("is_email_valid")
+    private Boolean isEmailValid; //이메일 유효 여부
+
+    @JsonProperty("is_email_verified")
+    private Boolean isEmailVerified; //이메일 인증 여부
+
+    private String email;
+
+    private Profile profile; //프로필 정보 -> 여기에 닉네임 있음
+
+
+    @NoArgsConstructor
+    @Getter
+    public static class Profile{
+        private String nickname;
+    }
+}

--- a/src/main/java/com/my/foody/infra/oauth/dto/kakao/KakaoTokenRespDto.java
+++ b/src/main/java/com/my/foody/infra/oauth/dto/kakao/KakaoTokenRespDto.java
@@ -1,0 +1,31 @@
+package com.my.foody.infra.oauth.dto.kakao;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.my.foody.infra.oauth.dto.TokenRespDto;
+
+public class KakaoTokenRespDto implements TokenRespDto {
+    @JsonProperty("access_token")
+    private String accessToken;
+
+    @JsonProperty("token_type")
+    private String tokenType;
+
+    @JsonProperty("id_token")
+    private String idToken;
+
+    @JsonProperty("expires_in")
+    private Integer expiresIn;
+    @JsonProperty("refresh_token")
+    private String refreshToken;
+    @JsonProperty("refresh_token_expires_in")
+    private Integer refreshTokenExpiresIn;
+
+    //허용된 권한
+    @JsonProperty("scope")
+    private String scope;
+
+    @Override
+    public String getAccessToken() {
+        return this.accessToken;
+    }
+}

--- a/src/main/java/com/my/foody/infra/oauth/dto/kakao/KakaoUserInfo.java
+++ b/src/main/java/com/my/foody/infra/oauth/dto/kakao/KakaoUserInfo.java
@@ -1,6 +1,7 @@
 package com.my.foody.infra.oauth.dto.kakao;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.my.foody.domain.user.entity.User;
 import com.my.foody.infra.oauth.common.OAuth2UserInfo;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -26,6 +27,15 @@ public class KakaoUserInfo implements OAuth2UserInfo {
     @Override
     public String getName() {
         return kakaoAccount.getProfile().getNickname();
+    }
+
+    @Override
+    public User toEntity() {
+        return User.builder()
+                .email(getEmail())
+                .nickname(getName())
+                .name(getName())
+                .build();
     }
 }
 

--- a/src/main/java/com/my/foody/infra/oauth/dto/kakao/KakaoUserInfo.java
+++ b/src/main/java/com/my/foody/infra/oauth/dto/kakao/KakaoUserInfo.java
@@ -35,6 +35,7 @@ public class KakaoUserInfo implements OAuth2UserInfo {
                 .email(getEmail())
                 .nickname(getName())
                 .name(getName())
+                .isDeleted(false)
                 .build();
     }
 }

--- a/src/main/java/com/my/foody/infra/oauth/dto/kakao/KakaoUserInfo.java
+++ b/src/main/java/com/my/foody/infra/oauth/dto/kakao/KakaoUserInfo.java
@@ -1,0 +1,31 @@
+package com.my.foody.infra.oauth.dto.kakao;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.my.foody.infra.oauth.common.OAuth2UserInfo;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+
+@NoArgsConstructor
+@Getter
+public class KakaoUserInfo implements OAuth2UserInfo {
+    private Long id; //회원번호
+    @JsonProperty("kakao_account")
+    private KakaoAccountDto kakaoAccount;
+
+    @Override
+    public String getProviderId() {
+        return id.toString();
+    }
+
+    @Override
+    public String getEmail() {
+        return kakaoAccount.getEmail();
+    }
+
+    @Override
+    public String getName() {
+        return kakaoAccount.getProfile().getNickname();
+    }
+}
+

--- a/src/main/java/com/my/foody/infra/oauth/google/GoogleApiClient.java
+++ b/src/main/java/com/my/foody/infra/oauth/google/GoogleApiClient.java
@@ -1,0 +1,17 @@
+package com.my.foody.infra.oauth.google;
+
+import com.my.foody.infra.oauth.config.OAuthFeignConfig;
+import com.my.foody.infra.oauth.dto.google.GoogleUserInfo;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+
+@FeignClient(name = "googleApiClient", url = "https://www.googleapis.com", configuration = OAuthFeignConfig.class)
+public interface GoogleApiClient {
+
+    @GetMapping("/oauth2/v2/userinfo")
+    GoogleUserInfo getUserInfo(@RequestHeader("Authorization") String token);
+
+
+
+}

--- a/src/main/java/com/my/foody/infra/oauth/google/GoogleAuthClient.java
+++ b/src/main/java/com/my/foody/infra/oauth/google/GoogleAuthClient.java
@@ -1,0 +1,18 @@
+package com.my.foody.infra.oauth.google;
+
+import com.my.foody.infra.oauth.config.OAuthFeignConfig;
+import com.my.foody.infra.oauth.dto.google.GoogleTokenRespDto;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+
+@FeignClient(name = "googleAuthClient", url = "https://oauth2.googleapis.com", configuration = OAuthFeignConfig.class)
+public interface GoogleAuthClient {
+
+    @PostMapping(value = "/token", consumes = "application/x-www-form-urlencoded")
+    GoogleTokenRespDto getAccessToken(@RequestParam("client_id") String clientId,
+                                      @RequestParam("client_secret") String clientSecret,
+                                      @RequestParam("code")String code,
+                                      @RequestParam("grant_type")String grantType,
+                                      @RequestParam("redirect_uri") String redirectUri);
+}

--- a/src/main/java/com/my/foody/infra/oauth/google/GoogleOAuth2Client.java
+++ b/src/main/java/com/my/foody/infra/oauth/google/GoogleOAuth2Client.java
@@ -1,0 +1,36 @@
+package com.my.foody.infra.oauth.google;
+
+import com.my.foody.global.jwt.JwtVo;
+import com.my.foody.infra.oauth.common.OAuth2Client;
+import com.my.foody.infra.oauth.common.OAuth2Provider;
+import com.my.foody.infra.oauth.common.OAuth2UserInfo;
+import com.my.foody.infra.oauth.dto.google.GoogleTokenRespDto;
+import lombok.RequiredArgsConstructor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+@RequiredArgsConstructor
+public class GoogleOAuth2Client implements OAuth2Client<GoogleTokenRespDto> {
+    private final GoogleAuthClient googleAuthClient;
+    private final GoogleApiClient googleApiClient;
+    private final OAuth2Provider oAuth2Provider;
+    private final Logger log = LoggerFactory.getLogger(this.getClass());
+    private static final String GRANT_TYPE = "authorization_code";
+
+
+    @Override
+    public GoogleTokenRespDto getAccessToken(String code) {
+        return googleAuthClient.getAccessToken(
+                oAuth2Provider.getClientId(),
+                oAuth2Provider.getClientSecret(),
+                code,
+                GRANT_TYPE,
+                oAuth2Provider.getRedirectUri());
+    }
+
+    @Override
+    public OAuth2UserInfo getUserInfo(String accessToken) {
+        log.info("구글 accessToken : {}", accessToken);
+        return googleApiClient.getUserInfo(JwtVo.TOKEN_PREFIX+accessToken);
+    }
+}

--- a/src/main/java/com/my/foody/infra/oauth/kakao/KakaoApiClient.java
+++ b/src/main/java/com/my/foody/infra/oauth/kakao/KakaoApiClient.java
@@ -1,0 +1,15 @@
+package com.my.foody.infra.oauth.kakao;
+
+
+import com.my.foody.infra.oauth.config.OAuthFeignConfig;
+import com.my.foody.infra.oauth.dto.kakao.KakaoUserInfo;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+
+@FeignClient(name = "kakaoApiClient", url = "https://kapi.kakao.com", configuration = OAuthFeignConfig.class)
+public interface KakaoApiClient {
+    @GetMapping(value = "/v2/user/me", consumes = "application/x-www-form-urlencoded;charset=utf-8")
+    KakaoUserInfo getUserInfo(@RequestHeader("Authorization")String token);
+
+}

--- a/src/main/java/com/my/foody/infra/oauth/kakao/KakaoAuthClient.java
+++ b/src/main/java/com/my/foody/infra/oauth/kakao/KakaoAuthClient.java
@@ -1,0 +1,19 @@
+package com.my.foody.infra.oauth.kakao;
+
+import com.my.foody.infra.oauth.config.OAuthFeignConfig;
+import com.my.foody.infra.oauth.dto.kakao.KakaoTokenRespDto;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+
+@FeignClient(name = "KakaoAuthClient", url = "https://kauth.kakao.com/oauth", configuration = OAuthFeignConfig.class)
+public interface KakaoAuthClient {
+
+    @PostMapping(value = "/token", consumes = "application/x-www-form-urlencoded;charset=utf-8")
+    KakaoTokenRespDto getAccessToken(@RequestParam("client_id") String clientId,
+                                     @RequestParam("client_secret") String clientSecret,
+                                     @RequestParam("code")String code,
+                                     @RequestParam("grant_type")String grantType,
+                                     @RequestParam("redirect_uri") String redirectUri);
+
+}

--- a/src/main/java/com/my/foody/infra/oauth/kakao/KakaoOAuth2Client.java
+++ b/src/main/java/com/my/foody/infra/oauth/kakao/KakaoOAuth2Client.java
@@ -1,0 +1,38 @@
+package com.my.foody.infra.oauth.kakao;
+
+
+import com.my.foody.global.jwt.JwtVo;
+import com.my.foody.infra.oauth.common.OAuth2Client;
+import com.my.foody.infra.oauth.common.OAuth2Provider;
+import com.my.foody.infra.oauth.common.OAuth2UserInfo;
+import com.my.foody.infra.oauth.dto.kakao.KakaoTokenRespDto;
+import lombok.RequiredArgsConstructor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+@RequiredArgsConstructor
+public class KakaoOAuth2Client implements OAuth2Client<KakaoTokenRespDto> {
+
+    private final KakaoAuthClient kakaoAuthClient;
+    private final KakaoApiClient kakaoApiClient;
+    private final OAuth2Provider oAuth2Provider;
+    private final Logger log = LoggerFactory.getLogger(this.getClass());
+    private static final String GRANT_TYPE = "authorization_code";
+
+
+    @Override
+    public KakaoTokenRespDto getAccessToken(String code) {
+        return kakaoAuthClient.getAccessToken(
+                oAuth2Provider.getClientId(),
+                oAuth2Provider.getClientSecret(),
+                code,
+                GRANT_TYPE,
+                oAuth2Provider.getRedirectUri());
+    }
+
+    @Override
+    public OAuth2UserInfo getUserInfo(String accessToken) {
+        log.info("카카오 accessToken : {}", accessToken);
+        return kakaoApiClient.getUserInfo(JwtVo.TOKEN_PREFIX+accessToken);
+    }
+}

--- a/src/test/java/com/my/foody/domain/socialAccount/controller/SocialAccountControllerTest.java
+++ b/src/test/java/com/my/foody/domain/socialAccount/controller/SocialAccountControllerTest.java
@@ -1,0 +1,154 @@
+package com.my.foody.domain.socialAccount.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.my.foody.domain.socialAccount.dto.resp.SocialAccountListRespDto;
+import com.my.foody.domain.socialAccount.service.AccountLinkageService;
+import com.my.foody.domain.socialAccount.service.SocialAccountService;
+import com.my.foody.domain.user.controller.UserController;
+import com.my.foody.domain.user.entity.Provider;
+import com.my.foody.domain.user.service.UserService;
+import com.my.foody.global.ex.BusinessException;
+import com.my.foody.global.ex.ErrorCode;
+import com.my.foody.global.jwt.JwtProvider;
+import com.my.foody.global.jwt.JwtVo;
+import com.my.foody.global.jwt.TokenSubject;
+import com.my.foody.global.jwt.UserType;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(SocialAccountController.class)
+@AutoConfigureMockMvc
+class SocialAccountControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockBean
+    private SocialAccountService socialAccountService;
+
+    @MockBean
+    private JwtProvider jwtProvider;
+
+    @MockBean
+    private AccountLinkageService accountLinkageService;
+
+    @Test
+    @DisplayName("소셜 계정 목록 조회 성공 테스트")
+    void getAllSocialAccount_Success() throws Exception {
+        // given
+        Long userId = 1L;
+        String token = "test.token";
+        TokenSubject tokenSubject = new TokenSubject(userId, UserType.USER);
+
+
+        List<SocialAccountListRespDto.SocialAccountRespDto> accountList = List.of(
+                createSocialAccountRespDto(1L, Provider.KAKAO, "kakao@test.com"),
+                createSocialAccountRespDto(2L, Provider.GOOGLE, "google@test.com")
+        );
+        SocialAccountListRespDto response = new SocialAccountListRespDto();
+        ReflectionTestUtils.setField(response, "socialAccountList", accountList);
+        ReflectionTestUtils.setField(response, "totalCount", 2);
+
+        when(jwtProvider.validate(token)).thenReturn(tokenSubject);
+        when(socialAccountService.getAllSocialAccount(userId)).thenReturn(response);
+
+        // when & then
+        mockMvc.perform(get("/api/users/mypage/social-accounts")
+                        .header(JwtVo.HEADER, JwtVo.TOKEN_PREFIX + token))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.totalCount").value(2))
+                .andExpect(jsonPath("$.data.socialAccountList").isArray())
+                .andExpect(jsonPath("$.data.socialAccountList.length()").value(2))
+                .andExpect(jsonPath("$.data.socialAccountList[0].socialAccountId").value(1))
+                .andExpect(jsonPath("$.data.socialAccountList[0].provider").value("KAKAO"))
+                .andExpect(jsonPath("$.data.socialAccountList[0].email").value("kakao@test.com"))
+                .andExpect(jsonPath("$.data.socialAccountList[1].socialAccountId").value(2))
+                .andExpect(jsonPath("$.data.socialAccountList[1].provider").value("GOOGLE"))
+                .andExpect(jsonPath("$.data.socialAccountList[1].email").value("google@test.com"));
+
+        verify(socialAccountService).getAllSocialAccount(userId);
+    }
+
+    @Test
+    @DisplayName("소셜 계정 목록 조회 실패 테스트: 존재하지 않는 사용자")
+    void getAllSocialAccount_UserNotFound() throws Exception {
+        // given
+        Long userId = 1L;
+        String token = "test.token";
+        TokenSubject tokenSubject = new TokenSubject(userId, UserType.USER);
+
+        when(jwtProvider.validate(token)).thenReturn(tokenSubject);
+        when(socialAccountService.getAllSocialAccount(userId))
+                .thenThrow(new BusinessException(ErrorCode.USER_NOT_FOUND));
+
+        // when & then
+        mockMvc.perform(get("/api/users/mypage/social-accounts")
+                        .header(JwtVo.HEADER, JwtVo.TOKEN_PREFIX + token))
+                .andDo(print())
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.success").value(false))
+                .andExpect(jsonPath("$.apiError.msg").value("존재하지 않는 유저입니다"));
+
+        verify(socialAccountService).getAllSocialAccount(userId);
+    }
+
+    @Test
+    @DisplayName("소셜 계정 목록 조회 성공 테스트: 연동된 계정 없음")
+    void getAllSocialAccount_EmptyList() throws Exception {
+        // given
+        Long userId = 1L;
+        String token = "test.token";
+        TokenSubject tokenSubject = new TokenSubject(userId, UserType.USER);
+
+        SocialAccountListRespDto response = new SocialAccountListRespDto();
+        ReflectionTestUtils.setField(response, "socialAccountList", Collections.emptyList());
+        ReflectionTestUtils.setField(response, "totalCount", 0);
+
+        when(jwtProvider.validate(token)).thenReturn(tokenSubject);
+        when(socialAccountService.getAllSocialAccount(userId)).thenReturn(response);
+
+        // when & then
+        mockMvc.perform(get("/api/users/mypage/social-accounts")
+                        .header(JwtVo.HEADER, JwtVo.TOKEN_PREFIX + token))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.totalCount").value(0))
+                .andExpect(jsonPath("$.data.socialAccountList").isArray())
+                .andExpect(jsonPath("$.data.socialAccountList.length()").value(0));
+
+        verify(socialAccountService).getAllSocialAccount(userId);
+    }
+
+
+    private SocialAccountListRespDto.SocialAccountRespDto createSocialAccountRespDto(
+            Long id, Provider provider, String email) {
+        SocialAccountListRespDto.SocialAccountRespDto dto = new SocialAccountListRespDto.SocialAccountRespDto();
+        ReflectionTestUtils.setField(dto, "socialAccountId", id);
+        ReflectionTestUtils.setField(dto, "provider", provider);
+        ReflectionTestUtils.setField(dto, "email", email);
+        return dto;
+    }
+}

--- a/src/test/java/com/my/foody/domain/socialAccount/service/SocialAccountServiceTest.java
+++ b/src/test/java/com/my/foody/domain/socialAccount/service/SocialAccountServiceTest.java
@@ -1,0 +1,123 @@
+package com.my.foody.domain.socialAccount.service;
+
+import com.my.foody.domain.socialAccount.dto.resp.SocialAccountListRespDto;
+import com.my.foody.domain.socialAccount.entity.SocialAccount;
+import com.my.foody.domain.socialAccount.repo.SocialAccountRepository;
+import com.my.foody.domain.user.entity.Provider;
+import com.my.foody.domain.user.entity.User;
+import com.my.foody.domain.user.service.UserService;
+import com.my.foody.global.ex.BusinessException;
+import com.my.foody.global.ex.ErrorCode;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Collections;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class SocialAccountServiceTest {
+    @InjectMocks
+    private SocialAccountService socialAccountService;
+
+    @Mock
+    private UserService userService;
+    @Mock
+    private SocialAccountRepository socialAccountRepository;
+
+    @Test
+    @DisplayName("소셜 계정 목록 조회 성공 테스트")
+    void getAllSocialAccount_Success() {
+        // given
+        Long userId = 1L;
+        User user = mock(User.class);
+
+        // 소셜 계정 mock 데이터 생성
+        SocialAccount kakaoAccount = mock(SocialAccount.class);
+        when(kakaoAccount.getId()).thenReturn(1L);
+        when(kakaoAccount.getProvider()).thenReturn(Provider.KAKAO);
+        when(kakaoAccount.getEmail()).thenReturn("kakao@test.com");
+
+        SocialAccount googleAccount = mock(SocialAccount.class);
+        when(googleAccount.getId()).thenReturn(2L);
+        when(googleAccount.getProvider()).thenReturn(Provider.GOOGLE);
+        when(googleAccount.getEmail()).thenReturn("google@test.com");
+
+        List<SocialAccount> socialAccounts = List.of(kakaoAccount, googleAccount);
+
+        // mock 설정
+        when(userService.findActivateUserByIdOrFail(userId)).thenReturn(user);
+        when(socialAccountRepository.findByUser(user)).thenReturn(socialAccounts);
+
+        // when
+        SocialAccountListRespDto result = socialAccountService.getAllSocialAccount(userId);
+
+        // then
+        assertNotNull(result);
+        assertEquals(2, result.getTotalCount());
+        assertEquals(2, result.getSocialAccountList().size());
+
+        // 첫 번째 소셜 계정 검증
+        SocialAccountListRespDto.SocialAccountRespDto firstAccount = result.getSocialAccountList().get(0);
+        assertEquals(1L, firstAccount.getSocialAccountId());
+        assertEquals(Provider.KAKAO, firstAccount.getProvider());
+        assertEquals("kakao@test.com", firstAccount.getEmail());
+
+        // 두 번째 소셜 계정 검증
+        SocialAccountListRespDto.SocialAccountRespDto secondAccount = result.getSocialAccountList().get(1);
+        assertEquals(2L, secondAccount.getSocialAccountId());
+        assertEquals(Provider.GOOGLE, secondAccount.getProvider());
+        assertEquals("google@test.com", secondAccount.getEmail());
+
+        // 메서드 호출 검증
+        verify(userService).findActivateUserByIdOrFail(userId);
+        verify(socialAccountRepository).findByUser(user);
+    }
+
+    @Test
+    @DisplayName("소셜 계정 목록 조회 실패 테스트: 존재하지 않는 사용자")
+    void getAllSocialAccount_UserNotFound() {
+        // given
+        Long userId = 1L;
+        when(userService.findActivateUserByIdOrFail(userId))
+                .thenThrow(new BusinessException(ErrorCode.USER_NOT_FOUND));
+
+        // when & then
+        assertThatThrownBy(() -> socialAccountService.getAllSocialAccount(userId))
+                .isInstanceOf(BusinessException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.USER_NOT_FOUND);
+
+        verify(userService).findActivateUserByIdOrFail(userId);
+        verify(socialAccountRepository, never()).findByUser(any(User.class));
+    }
+
+    @Test
+    @DisplayName("소셜 계정 목록 조회 성공 테스트: 연동된 소셜 계정이 없는 경우")
+    void getAllSocialAccount_EmptyList() {
+        // given
+        Long userId = 1L;
+        User user = mock(User.class);
+        List<SocialAccount> emptyList = Collections.emptyList();
+
+        when(userService.findActivateUserByIdOrFail(userId)).thenReturn(user);
+        when(socialAccountRepository.findByUser(user)).thenReturn(emptyList);
+
+        // when
+        SocialAccountListRespDto result = socialAccountService.getAllSocialAccount(userId);
+
+        // then
+        assertNotNull(result);
+        assertEquals(0, result.getTotalCount());
+        assertTrue(result.getSocialAccountList().isEmpty());
+
+        verify(userService).findActivateUserByIdOrFail(userId);
+        verify(socialAccountRepository).findByUser(user);
+    }
+}


### PR DESCRIPTION
## 전체 시나리오
### 시나리오
1. 연동된 소셜 계정 조회 요청
2. 토큰 검증
3. 유저 검증 -> 존재하지 않을 시 에러 throw
4. 유저의 연동된 소셜 계정 조회
5. 조회된 계정 리스트 반환

## 서비스&컨트롤러 단위 테스트 추가
### **1. ✅ 조회 성공**
    - 연동된 소셜 계정이 있는 경우
    - 연동된 소셜 계정이 없는 경우

### **2. ❌ 실패 케이스**
    - 존재하지 않는 사용자: USER_NOT_FOUND 검증